### PR TITLE
feat: Implement File Upload API Endpoint [FEAT-006]

### DIFF
--- a/packages/backend/src/main/java/com/tracegrade/dto/response/BatchUploadResponse.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/response/BatchUploadResponse.java
@@ -1,0 +1,15 @@
+package com.tracegrade.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BatchUploadResponse {
+
+    private List<FileUploadResponse> submissions;
+    private int totalFiles;
+    private int successfulUploads;
+}

--- a/packages/backend/src/main/java/com/tracegrade/dto/response/FileUploadResponse.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/response/FileUploadResponse.java
@@ -1,0 +1,18 @@
+package com.tracegrade.dto.response;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FileUploadResponse {
+
+    private UUID submissionId;
+    private String fileUrl;
+    private String fileName;
+    private String status;
+    private Instant uploadedAt;
+}

--- a/packages/backend/src/main/java/com/tracegrade/exception/GlobalExceptionHandler.java
+++ b/packages/backend/src/main/java/com/tracegrade/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 import com.tracegrade.dto.response.ApiError;
 import com.tracegrade.dto.response.ApiResponse;
@@ -87,6 +88,23 @@ public class GlobalExceptionHandler {
         ApiError error = ApiError.withDetails(
                 "VALIDATION_ERROR",
                 "Missing required parameter",
+                List.of(detail));
+
+        return ResponseEntity.badRequest().body(ApiResponse.error(error));
+    }
+
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingRequestPart(
+            MissingServletRequestPartException ex) {
+        FieldError detail = FieldError.builder()
+                .field(ex.getRequestPartName())
+                .code("REQUIRED")
+                .message("Request part '" + ex.getRequestPartName() + "' is required")
+                .build();
+
+        ApiError error = ApiError.withDetails(
+                "VALIDATION_ERROR",
+                "Missing required request part",
                 List.of(detail));
 
         return ResponseEntity.badRequest().body(ApiResponse.error(error));

--- a/packages/backend/src/main/java/com/tracegrade/submission/StudentSubmissionController.java
+++ b/packages/backend/src/main/java/com/tracegrade/submission/StudentSubmissionController.java
@@ -1,0 +1,72 @@
+package com.tracegrade.submission;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.tracegrade.dto.response.ApiResponse;
+import com.tracegrade.dto.response.BatchUploadResponse;
+import com.tracegrade.dto.response.FileUploadResponse;
+import com.tracegrade.validation.ValidFileUpload;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/submissions")
+@RequiredArgsConstructor
+@Validated
+public class StudentSubmissionController {
+
+    private final SubmissionUploadService uploadService;
+
+    /**
+     * Upload a single exam submission image.
+     *
+     * POST /api/submissions/upload
+     * Content-Type: multipart/form-data
+     *
+     * @param assignmentId the assignment this submission belongs to
+     * @param studentId    the student making the submission
+     * @param file         the exam image file (JPEG, PNG, PDF, or HEIC; max 10 MB)
+     */
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<FileUploadResponse>> uploadFile(
+            @RequestParam @NotNull UUID assignmentId,
+            @RequestParam @NotNull UUID studentId,
+            @RequestPart("file") @ValidFileUpload MultipartFile file) {
+
+        FileUploadResponse response = uploadService.uploadSingle(assignmentId, studentId, file);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * Upload multiple exam submission images in a single request.
+     *
+     * POST /api/submissions/upload/batch
+     * Content-Type: multipart/form-data
+     *
+     * @param assignmentId the assignment these submissions belong to
+     * @param studentId    the student making the submissions
+     * @param files        the exam image files (each: JPEG, PNG, PDF, or HEIC; max 10 MB)
+     */
+    @PostMapping(value = "/upload/batch", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<BatchUploadResponse>> uploadFiles(
+            @RequestParam @NotNull UUID assignmentId,
+            @RequestParam @NotNull UUID studentId,
+            @RequestPart("files") @NotEmpty List<@ValidFileUpload MultipartFile> files) {
+
+        BatchUploadResponse response = uploadService.uploadBatch(assignmentId, studentId, files);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/packages/backend/src/main/java/com/tracegrade/submission/SubmissionUploadService.java
+++ b/packages/backend/src/main/java/com/tracegrade/submission/SubmissionUploadService.java
@@ -1,0 +1,92 @@
+package com.tracegrade.submission;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.tracegrade.domain.model.StudentSubmission;
+import com.tracegrade.domain.model.SubmissionStatus;
+import com.tracegrade.domain.repository.StudentSubmissionRepository;
+import com.tracegrade.dto.response.BatchUploadResponse;
+import com.tracegrade.dto.response.FileUploadResponse;
+import com.tracegrade.exception.StorageException;
+import com.tracegrade.storage.StorageService;
+import com.tracegrade.storage.StorageType;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SubmissionUploadService {
+
+    private final StorageService storageService;
+    private final StudentSubmissionRepository submissionRepository;
+
+    @Transactional
+    public FileUploadResponse uploadSingle(UUID assignmentId, UUID studentId, MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        String format = extractFormat(originalFilename);
+        String contentType = file.getContentType() != null ? file.getContentType() : "application/octet-stream";
+
+        byte[] content;
+        try {
+            content = file.getBytes();
+        } catch (IOException e) {
+            throw new StorageException("upload", "Failed to read uploaded file: " + e.getMessage(), e);
+        }
+
+        log.info("Uploading submission for assignmentId={} studentId={} fileName={}", assignmentId, studentId, originalFilename);
+
+        String storageKey = storageService.upload(StorageType.SUBMISSION_IMAGE, originalFilename, content, contentType);
+        String fileUrl = storageService.getPublicUrl(storageKey);
+
+        Instant now = Instant.now();
+        StudentSubmission submission = StudentSubmission.builder()
+                .assignmentId(assignmentId)
+                .studentId(studentId)
+                .submissionImageUrls("[\"" + fileUrl + "\"]")
+                .originalFormat(format)
+                .status(SubmissionStatus.PENDING)
+                .submittedAt(now)
+                .build();
+
+        StudentSubmission saved = submissionRepository.save(submission);
+        log.info("Submission created id={}", saved.getId());
+
+        return FileUploadResponse.builder()
+                .submissionId(saved.getId())
+                .fileUrl(fileUrl)
+                .fileName(originalFilename)
+                .status(saved.getStatus().name())
+                .uploadedAt(saved.getSubmittedAt())
+                .build();
+    }
+
+    @Transactional
+    public BatchUploadResponse uploadBatch(UUID assignmentId, UUID studentId, List<MultipartFile> files) {
+        List<FileUploadResponse> results = files.stream()
+                .map(file -> uploadSingle(assignmentId, studentId, file))
+                .toList();
+
+        return BatchUploadResponse.builder()
+                .submissions(results)
+                .totalFiles(files.size())
+                .successfulUploads(results.size())
+                .build();
+    }
+
+    private String extractFormat(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            return "unknown";
+        }
+        String ext = filename.substring(filename.lastIndexOf('.') + 1).toLowerCase();
+        return ext.length() > 10 ? ext.substring(0, 10) : ext;
+    }
+}

--- a/packages/backend/src/main/java/com/tracegrade/validation/ValidFileUpload.java
+++ b/packages/backend/src/main/java/com/tracegrade/validation/ValidFileUpload.java
@@ -11,7 +11,7 @@ import jakarta.validation.Payload;
 
 @Documented
 @Constraint(validatedBy = FileUploadValidator.class)
-@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ValidFileUpload {
 

--- a/packages/backend/src/test/java/com/tracegrade/submission/StudentSubmissionControllerTest.java
+++ b/packages/backend/src/test/java/com/tracegrade/submission/StudentSubmissionControllerTest.java
@@ -1,0 +1,196 @@
+package com.tracegrade.submission;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.tracegrade.config.CsrfAccessDeniedHandler;
+import com.tracegrade.config.CsrfProperties;
+import com.tracegrade.config.SecurityConfig;
+import com.tracegrade.config.SecurityHeadersProperties;
+import com.tracegrade.dto.response.BatchUploadResponse;
+import com.tracegrade.dto.response.FileUploadResponse;
+import com.tracegrade.filter.SanitizationProperties;
+import com.tracegrade.ratelimit.RateLimitProperties;
+import com.tracegrade.ratelimit.RateLimitService;
+
+import java.util.List;
+
+@WebMvcTest(StudentSubmissionController.class)
+@Import({SecurityConfig.class, SecurityHeadersProperties.class,
+         CsrfProperties.class, CsrfAccessDeniedHandler.class,
+         RateLimitProperties.class, SanitizationProperties.class})
+@TestPropertySource(properties = {
+        "security-headers.https-redirect-enabled=false",
+        "rate-limit.enabled=false",
+        "sanitization.enabled=false",
+        "csrf.enabled=false"
+})
+@SuppressWarnings("null") // Hamcrest is() / csrf() vs @NonNull MockMvc API contracts
+class StudentSubmissionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SubmissionUploadService uploadService;
+
+    @MockBean
+    private RateLimitService rateLimitService;
+
+    // JPEG magic bytes prefix — ensures @ValidFileUpload passes in tests
+    private static final byte[] JPEG_BYTES = {
+        (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    };
+
+    private static final UUID ASSIGNMENT_ID = UUID.randomUUID();
+    private static final UUID STUDENT_ID    = UUID.randomUUID();
+
+    @Nested
+    @DisplayName("POST /api/submissions/upload")
+    class SingleUploadTests {
+
+        @Test
+        @DisplayName("Should return 200 with FileUploadResponse on valid upload")
+        void validUpload() throws Exception {
+            UUID submissionId = UUID.randomUUID();
+            FileUploadResponse stubResponse = FileUploadResponse.builder()
+                    .submissionId(submissionId)
+                    .fileUrl("https://bucket/submissions/exam.jpg")
+                    .fileName("exam.jpg")
+                    .status("PENDING")
+                    .uploadedAt(Instant.now())
+                    .build();
+
+            when(uploadService.uploadSingle(eq(ASSIGNMENT_ID), eq(STUDENT_ID), any()))
+                    .thenReturn(stubResponse);
+
+            MockMultipartFile file = new MockMultipartFile("file", "exam.jpg", "image/jpeg", JPEG_BYTES);
+
+            mockMvc.perform(multipart("/api/submissions/upload")
+                            .file(file)
+                            .param("assignmentId", ASSIGNMENT_ID.toString())
+                            .param("studentId", STUDENT_ID.toString())
+                            .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success", is(true)))
+                    .andExpect(jsonPath("$.data.submissionId", is(submissionId.toString())))
+                    .andExpect(jsonPath("$.data.fileUrl", is("https://bucket/submissions/exam.jpg")))
+                    .andExpect(jsonPath("$.data.status", is("PENDING")));
+
+            verify(uploadService).uploadSingle(eq(ASSIGNMENT_ID), eq(STUDENT_ID), any());
+        }
+
+        @Test
+        @DisplayName("Should return 400 when file type is invalid")
+        void invalidFileType() throws Exception {
+            // Bytes that do not match any allowed magic number
+            byte[] exeBytes = new byte[]{'M', 'Z', 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+            MockMultipartFile file = new MockMultipartFile("file", "malware.exe", "application/octet-stream", exeBytes);
+
+            mockMvc.perform(multipart("/api/submissions/upload")
+                            .file(file)
+                            .param("assignmentId", ASSIGNMENT_ID.toString())
+                            .param("studentId", STUDENT_ID.toString())
+                            .with(csrf()))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("Should return 400 when assignmentId is missing")
+        void missingAssignmentId() throws Exception {
+            MockMultipartFile file = new MockMultipartFile("file", "exam.jpg", "image/jpeg", JPEG_BYTES);
+
+            mockMvc.perform(multipart("/api/submissions/upload")
+                            .file(file)
+                            .param("studentId", STUDENT_ID.toString())
+                            .with(csrf()))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("Should return 400 when studentId is missing")
+        void missingStudentId() throws Exception {
+            MockMultipartFile file = new MockMultipartFile("file", "exam.jpg", "image/jpeg", JPEG_BYTES);
+
+            mockMvc.perform(multipart("/api/submissions/upload")
+                            .file(file)
+                            .param("assignmentId", ASSIGNMENT_ID.toString())
+                            .with(csrf()))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/submissions/upload/batch")
+    class BatchUploadTests {
+
+        @Test
+        @DisplayName("Should return 200 with BatchUploadResponse on valid batch upload")
+        void validBatchUpload() throws Exception {
+            UUID id1 = UUID.randomUUID();
+            UUID id2 = UUID.randomUUID();
+
+            BatchUploadResponse stubResponse = BatchUploadResponse.builder()
+                    .submissions(List.of(
+                            FileUploadResponse.builder().submissionId(id1).fileUrl("https://bucket/page1.jpg")
+                                    .fileName("page1.jpg").status("PENDING").uploadedAt(Instant.now()).build(),
+                            FileUploadResponse.builder().submissionId(id2).fileUrl("https://bucket/page2.jpg")
+                                    .fileName("page2.jpg").status("PENDING").uploadedAt(Instant.now()).build()
+                    ))
+                    .totalFiles(2)
+                    .successfulUploads(2)
+                    .build();
+
+            when(uploadService.uploadBatch(eq(ASSIGNMENT_ID), eq(STUDENT_ID), any()))
+                    .thenReturn(stubResponse);
+
+            MockMultipartFile file1 = new MockMultipartFile("files", "page1.jpg", "image/jpeg", JPEG_BYTES);
+            MockMultipartFile file2 = new MockMultipartFile("files", "page2.jpg", "image/jpeg", JPEG_BYTES);
+
+            mockMvc.perform(multipart("/api/submissions/upload/batch")
+                            .file(file1)
+                            .file(file2)
+                            .param("assignmentId", ASSIGNMENT_ID.toString())
+                            .param("studentId", STUDENT_ID.toString())
+                            .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success", is(true)))
+                    .andExpect(jsonPath("$.data.totalFiles", is(2)))
+                    .andExpect(jsonPath("$.data.successfulUploads", is(2)))
+                    .andExpect(jsonPath("$.data.submissions.length()", is(2)));
+
+            verify(uploadService).uploadBatch(eq(ASSIGNMENT_ID), eq(STUDENT_ID), any());
+        }
+
+        @Test
+        @DisplayName("Should return 400 when files list is empty")
+        void emptyFilesList() throws Exception {
+            mockMvc.perform(multipart("/api/submissions/upload/batch")
+                            .param("assignmentId", ASSIGNMENT_ID.toString())
+                            .param("studentId", STUDENT_ID.toString())
+                            .with(csrf()))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/packages/backend/src/test/java/com/tracegrade/submission/SubmissionUploadServiceTest.java
+++ b/packages/backend/src/test/java/com/tracegrade/submission/SubmissionUploadServiceTest.java
@@ -1,0 +1,194 @@
+package com.tracegrade.submission;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import com.tracegrade.domain.model.StudentSubmission;
+import com.tracegrade.domain.model.SubmissionStatus;
+import com.tracegrade.domain.repository.StudentSubmissionRepository;
+import com.tracegrade.dto.response.BatchUploadResponse;
+import com.tracegrade.dto.response.FileUploadResponse;
+import com.tracegrade.exception.StorageException;
+import com.tracegrade.storage.StorageService;
+import com.tracegrade.storage.StorageType;
+
+@SuppressWarnings("null") // Mockito thenReturn vs @NonNull JpaRepository.save() return type
+class SubmissionUploadServiceTest {
+
+    private StorageService storageService;
+    private StudentSubmissionRepository submissionRepository;
+    private SubmissionUploadService service;
+
+    private static final UUID ASSIGNMENT_ID = UUID.randomUUID();
+    private static final UUID STUDENT_ID = UUID.randomUUID();
+    private static final String STORAGE_KEY = "submissions/uuid_exam.jpg";
+    private static final String FILE_URL = "https://bucket.s3.amazonaws.com/" + STORAGE_KEY;
+
+    @BeforeEach
+    void setUp() {
+        storageService = mock(StorageService.class);
+        submissionRepository = mock(StudentSubmissionRepository.class);
+        service = new SubmissionUploadService(storageService, submissionRepository);
+    }
+
+    @Nested
+    @DisplayName("Single upload")
+    class SingleUploadTests {
+
+        @Test
+        @DisplayName("Should upload file to S3 and persist submission entity")
+        void uploadSingleSuccess() {
+            MockMultipartFile file = new MockMultipartFile(
+                    "file", "exam.jpg", "image/jpeg", "jpeg content".getBytes());
+
+            when(storageService.upload(eq(StorageType.SUBMISSION_IMAGE), eq("exam.jpg"), any(), eq("image/jpeg")))
+                    .thenReturn(STORAGE_KEY);
+            when(storageService.getPublicUrl(STORAGE_KEY)).thenReturn(FILE_URL);
+
+            StudentSubmission saved = buildSavedSubmission(FILE_URL, "jpg");
+            when(submissionRepository.save(any(StudentSubmission.class))).thenReturn(saved);
+
+            FileUploadResponse response = service.uploadSingle(ASSIGNMENT_ID, STUDENT_ID, file);
+
+            assertThat(response.getSubmissionId()).isEqualTo(saved.getId());
+            assertThat(response.getFileUrl()).isEqualTo(FILE_URL);
+            assertThat(response.getFileName()).isEqualTo("exam.jpg");
+            assertThat(response.getStatus()).isEqualTo(SubmissionStatus.PENDING.name());
+            assertThat(response.getUploadedAt()).isNotNull();
+
+            verify(storageService).upload(StorageType.SUBMISSION_IMAGE, "exam.jpg", "jpeg content".getBytes(), "image/jpeg");
+            verify(submissionRepository).save(any(StudentSubmission.class));
+        }
+
+        @Test
+        @DisplayName("Should use 'application/octet-stream' when content type is null")
+        void uploadWithNullContentType() {
+            MockMultipartFile file = new MockMultipartFile("file", "scan.png", null, "png content".getBytes());
+
+            when(storageService.upload(eq(StorageType.SUBMISSION_IMAGE), eq("scan.png"), any(), eq("application/octet-stream")))
+                    .thenReturn(STORAGE_KEY);
+            when(storageService.getPublicUrl(STORAGE_KEY)).thenReturn(FILE_URL);
+            when(submissionRepository.save(any())).thenReturn(buildSavedSubmission(FILE_URL, "png"));
+
+            service.uploadSingle(ASSIGNMENT_ID, STUDENT_ID, file);
+
+            verify(storageService).upload(StorageType.SUBMISSION_IMAGE, "scan.png", "png content".getBytes(), "application/octet-stream");
+        }
+
+        @Test
+        @DisplayName("Should extract format 'unknown' when filename has no extension")
+        void uploadWithNoExtensionFilename() {
+            MockMultipartFile file = new MockMultipartFile("file", "scanimage", "image/jpeg", "jpeg content".getBytes());
+
+            when(storageService.upload(any(), any(), any(), any())).thenReturn(STORAGE_KEY);
+            when(storageService.getPublicUrl(any())).thenReturn(FILE_URL);
+
+            StudentSubmission saved = buildSavedSubmission(FILE_URL, "unknown");
+            when(submissionRepository.save(any())).thenReturn(saved);
+
+            service.uploadSingle(ASSIGNMENT_ID, STUDENT_ID, file);
+
+            verify(submissionRepository).save(any(StudentSubmission.class));
+        }
+
+        @Test
+        @DisplayName("Should throw StorageException when S3 upload fails")
+        void uploadStorageFailure() {
+            MockMultipartFile file = new MockMultipartFile("file", "exam.jpg", "image/jpeg", "bytes".getBytes());
+
+            when(storageService.upload(any(), any(), any(), any()))
+                    .thenThrow(new StorageException("upload", "S3 unreachable"));
+
+            assertThatThrownBy(() -> service.uploadSingle(ASSIGNMENT_ID, STUDENT_ID, file))
+                    .isInstanceOf(StorageException.class)
+                    .hasMessageContaining("S3 unreachable");
+        }
+
+        @Test
+        @DisplayName("Should wrap IOException in StorageException")
+        void uploadIOException() throws IOException {
+            MockMultipartFile file = mock(MockMultipartFile.class);
+            when(file.getOriginalFilename()).thenReturn("exam.jpg");
+            when(file.getContentType()).thenReturn("image/jpeg");
+            when(file.getBytes()).thenThrow(new IOException("disk error"));
+
+            assertThatThrownBy(() -> service.uploadSingle(ASSIGNMENT_ID, STUDENT_ID, file))
+                    .isInstanceOf(StorageException.class)
+                    .hasMessageContaining("disk error");
+        }
+    }
+
+    @Nested
+    @DisplayName("Batch upload")
+    class BatchUploadTests {
+
+        @Test
+        @DisplayName("Should upload each file and return all results")
+        void uploadBatchSuccess() {
+            MockMultipartFile file1 = new MockMultipartFile("files", "page1.jpg", "image/jpeg", "bytes1".getBytes());
+            MockMultipartFile file2 = new MockMultipartFile("files", "page2.jpg", "image/jpeg", "bytes2".getBytes());
+
+            String key1 = "submissions/uuid1_page1.jpg";
+            String key2 = "submissions/uuid2_page2.jpg";
+            String url1 = "https://bucket/" + key1;
+            String url2 = "https://bucket/" + key2;
+
+            when(storageService.upload(eq(StorageType.SUBMISSION_IMAGE), eq("page1.jpg"), any(), any())).thenReturn(key1);
+            when(storageService.upload(eq(StorageType.SUBMISSION_IMAGE), eq("page2.jpg"), any(), any())).thenReturn(key2);
+            when(storageService.getPublicUrl(key1)).thenReturn(url1);
+            when(storageService.getPublicUrl(key2)).thenReturn(url2);
+            when(submissionRepository.save(any()))
+                    .thenReturn(buildSavedSubmission(url1, "jpg"))
+                    .thenReturn(buildSavedSubmission(url2, "jpg"));
+
+            BatchUploadResponse response = service.uploadBatch(ASSIGNMENT_ID, STUDENT_ID, List.of(file1, file2));
+
+            assertThat(response.getTotalFiles()).isEqualTo(2);
+            assertThat(response.getSuccessfulUploads()).isEqualTo(2);
+            assertThat(response.getSubmissions()).hasSize(2);
+
+            verify(storageService, times(2)).upload(eq(StorageType.SUBMISSION_IMAGE), any(), any(), any());
+            verify(submissionRepository, times(2)).save(any(StudentSubmission.class));
+        }
+
+        @Test
+        @DisplayName("Should propagate StorageException on first file failure")
+        void uploadBatchFailsOnFirstError() {
+            MockMultipartFile file1 = new MockMultipartFile("files", "page1.jpg", "image/jpeg", "bytes".getBytes());
+            MockMultipartFile file2 = new MockMultipartFile("files", "page2.jpg", "image/jpeg", "bytes".getBytes());
+
+            when(storageService.upload(any(), any(), any(), any()))
+                    .thenThrow(new StorageException("upload", "S3 error"));
+
+            assertThatThrownBy(() -> service.uploadBatch(ASSIGNMENT_ID, STUDENT_ID, List.of(file1, file2)))
+                    .isInstanceOf(StorageException.class);
+        }
+    }
+
+    private StudentSubmission buildSavedSubmission(String fileUrl, String format) {
+        return StudentSubmission.builder()
+                .assignmentId(ASSIGNMENT_ID)
+                .studentId(STUDENT_ID)
+                .submissionImageUrls("[\"" + fileUrl + "\"]")
+                .originalFormat(format)
+                .status(SubmissionStatus.PENDING)
+                .submittedAt(java.time.Instant.now())
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #6

- Adds `POST /api/submissions/upload` — single exam image upload (JPEG, PNG, PDF, HEIC; max 10 MB)
- Adds `POST /api/submissions/upload/batch` — batch upload of multiple files in one request
- `SubmissionUploadService` uploads each file to S3 via the existing `StorageService`, then persists a `StudentSubmission` entity with `PENDING` status
- Per-file validation (`@ValidFileUpload`) enforces magic-byte file type checking and size limits; `@ValidFileUpload` now also supports `TYPE_USE` so it works inside `List<@ValidFileUpload MultipartFile>`
- `GlobalExceptionHandler` updated to return 400 (not 500) for missing `@RequestPart` fields

## Test plan

- [x] 13 unit tests pass (`SubmissionUploadServiceTest`, `StudentSubmissionControllerTest`)
- [x] Happy path: valid JPEG uploaded → 200 with `submissionId`, `fileUrl`, `status=PENDING`
- [x] Invalid file type (exe magic bytes) → 400
- [x] Missing `assignmentId` or `studentId` → 400
- [x] Batch upload with two files → 200 with `totalFiles=2`, `successfulUploads=2`
- [x] Empty files list on batch endpoint → 400
- [x] S3 failure propagates as `StorageException` → 502 (via existing handler)
- [x] `IOException` reading file bytes wrapped in `StorageException`
