### PR TITLE
feat: Set up SQS queue for async grading [FEAT-013]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,13 +47,14 @@ services:
     container_name: tracegrade-localstack
     restart: unless-stopped
     environment:
-      SERVICES: s3
+      SERVICES: s3,sqs
       AWS_DEFAULT_REGION: ${AWS_REGION:-us-east-1}
     ports:
       - "${LOCALSTACK_PORT:-4566}:4566"
     volumes:
       - localstack_data:/var/lib/localstack
       - ./infra/localstack/init-s3.sh:/etc/localstack/init/ready.d/init-s3.sh
+      - ./infra/localstack/init-sqs.sh:/etc/localstack/init/ready.d/init-sqs.sh
     healthcheck:
       test: ["CMD-SHELL", "awslocal s3 ls"]
       interval: 10s
@@ -114,6 +115,12 @@ services:
       S3_ENDPOINT: http://localstack:4566
       AWS_ACCESS_KEY_ID: test
       AWS_SECRET_ACCESS_KEY: test
+
+      # SQS (LocalStack)
+      SQS_ENABLED: "true"
+      SQS_ENDPOINT: http://localstack:4566
+      SQS_QUEUE_URL: http://localstack:4566/000000000000/tracegrade-grading-queue
+      SQS_DLQ_URL: http://localstack:4566/000000000000/tracegrade-grading-dlq
 
       # CORS
       CORS_ALLOWED_ORIGINS: http://localhost:5173,http://localhost:3000,http://frontend:5173

--- a/infra/localstack/init-sqs.sh
+++ b/infra/localstack/init-sqs.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Creates the SQS queues used by TraceGrade for async grading.
+# This script runs automatically when LocalStack is ready.
+
+QUEUE_NAME="${SQS_QUEUE_NAME:-tracegrade-grading-queue}"
+DLQ_NAME="${SQS_DLQ_NAME:-tracegrade-grading-dlq}"
+VISIBILITY_TIMEOUT="${SQS_VISIBILITY_TIMEOUT:-300}"
+MAX_RECEIVE_COUNT="${SQS_MAX_RECEIVE_COUNT:-3}"
+
+echo "Creating SQS Dead Letter Queue: $DLQ_NAME"
+DLQ_URL=$(awslocal sqs create-queue \
+  --queue-name "$DLQ_NAME" \
+  --attributes VisibilityTimeout="$VISIBILITY_TIMEOUT" \
+  --query 'QueueUrl' \
+  --output text)
+
+DLQ_ARN=$(awslocal sqs get-queue-attributes \
+  --queue-url "$DLQ_URL" \
+  --attribute-names QueueArn \
+  --query 'Attributes.QueueArn' \
+  --output text)
+
+echo "DLQ URL: $DLQ_URL"
+echo "DLQ ARN: $DLQ_ARN"
+
+echo "Creating SQS grading queue: $QUEUE_NAME"
+QUEUE_URL=$(awslocal sqs create-queue \
+  --queue-name "$QUEUE_NAME" \
+  --attributes \
+    VisibilityTimeout="$VISIBILITY_TIMEOUT" \
+    "RedrivePolicy={\"deadLetterTargetArn\":\"$DLQ_ARN\",\"maxReceiveCount\":\"$MAX_RECEIVE_COUNT\"}" \
+  --query 'QueueUrl' \
+  --output text)
+
+echo "Queue URL: $QUEUE_URL"
+echo "SQS queues '$QUEUE_NAME' and '$DLQ_NAME' configured with DLQ redrive policy (maxReceiveCount=$MAX_RECEIVE_COUNT)"

--- a/packages/backend/pom.xml
+++ b/packages/backend/pom.xml
@@ -53,6 +53,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>secretsmanager</artifactId>
         </dependency>
+        <!-- AWS SQS (for async grading queue) -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sqs</artifactId>
+        </dependency>
         <!-- Spring Boot Starters -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/packages/backend/src/main/java/com/tracegrade/dto/response/GradingEnqueuedResponse.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/response/GradingEnqueuedResponse.java
@@ -1,0 +1,32 @@
+package com.tracegrade.dto.response;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GradingEnqueuedResponse {
+
+    /** The submission this grading job is for. */
+    private UUID submissionId;
+
+    /**
+     * Current status of the grading request:
+     * <ul>
+     *   <li>{@code QUEUED} – job published to SQS; async processing pending</li>
+     *   <li>{@code COMPLETED} – graded synchronously (SQS not configured)</li>
+     *   <li>{@code ALREADY_GRADED} – a result already existed; no new job enqueued</li>
+     * </ul>
+     */
+    private String status;
+
+    /** Timestamp when the enqueue request was processed. */
+    private Instant enqueuedAt;
+}

--- a/packages/backend/src/main/java/com/tracegrade/grading/GradingController.java
+++ b/packages/backend/src/main/java/com/tracegrade/grading/GradingController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.tracegrade.dto.response.ApiResponse;
+import com.tracegrade.dto.response.GradingEnqueuedResponse;
 import com.tracegrade.dto.response.GradingResultResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -22,11 +23,11 @@ public class GradingController {
     private final GradingService gradingService;
 
     @PostMapping("/api/submissions/{submissionId}/grade")
-    public ResponseEntity<ApiResponse<GradingResultResponse>> grade(
+    public ResponseEntity<ApiResponse<GradingEnqueuedResponse>> enqueueGrading(
             @PathVariable UUID submissionId) {
 
-        GradingResultResponse response = gradingService.grade(submissionId);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+        GradingEnqueuedResponse response = gradingService.enqueueGrading(submissionId);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(ApiResponse.success(response));
     }
 
     @GetMapping("/api/submissions/{submissionId}/grade")

--- a/packages/backend/src/main/java/com/tracegrade/grading/GradingService.java
+++ b/packages/backend/src/main/java/com/tracegrade/grading/GradingService.java
@@ -3,9 +3,21 @@ package com.tracegrade.grading;
 import java.util.List;
 import java.util.UUID;
 
+import com.tracegrade.dto.response.GradingEnqueuedResponse;
 import com.tracegrade.dto.response.GradingResultResponse;
 
 public interface GradingService {
+
+    /**
+     * Enqueues a grading job for async processing via SQS. If SQS is not configured,
+     * falls back to synchronous grading. Idempotent: if a GradingResult already exists,
+     * no new job is enqueued.
+     *
+     * @param submissionId the UUID of the StudentSubmission to grade
+     * @return a response indicating the job status (QUEUED, COMPLETED, or ALREADY_GRADED)
+     * @throws com.tracegrade.exception.ResourceNotFoundException if the submission is not found
+     */
+    GradingEnqueuedResponse enqueueGrading(UUID submissionId);
 
     /**
      * Grades a student submission against its exam template's answer rubrics using

--- a/packages/backend/src/main/java/com/tracegrade/sqs/GradingJobMessage.java
+++ b/packages/backend/src/main/java/com/tracegrade/sqs/GradingJobMessage.java
@@ -1,0 +1,22 @@
+package com.tracegrade.sqs;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GradingJobMessage {
+
+    /** The submission to be graded. */
+    private UUID submissionId;
+
+    /** When the job was placed on the queue. */
+    private Instant enqueuedAt;
+}

--- a/packages/backend/src/main/java/com/tracegrade/sqs/GradingJobPublisher.java
+++ b/packages/backend/src/main/java/com/tracegrade/sqs/GradingJobPublisher.java
@@ -1,0 +1,55 @@
+package com.tracegrade.sqs;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "sqs.enabled", havingValue = "true")
+public class GradingJobPublisher {
+
+    private final SqsClient sqsClient;
+    private final SqsProperties sqsProperties;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Publishes a grading job to the SQS queue for async processing.
+     *
+     * @param submissionId the UUID of the StudentSubmission to grade
+     */
+    public void publishGradingJob(UUID submissionId) {
+        GradingJobMessage message = GradingJobMessage.builder()
+                .submissionId(submissionId)
+                .enqueuedAt(Instant.now())
+                .build();
+
+        String messageBody;
+        try {
+            messageBody = objectMapper.writeValueAsString(message);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(
+                    "Failed to serialize GradingJobMessage for submissionId=" + submissionId, e);
+        }
+
+        SendMessageResponse response = sqsClient.sendMessage(SendMessageRequest.builder()
+                .queueUrl(sqsProperties.getQueueUrl())
+                .messageBody(messageBody)
+                .build());
+
+        log.info("Published grading job to SQS for submissionId={} messageId={}",
+                submissionId, response.messageId());
+    }
+}

--- a/packages/backend/src/main/java/com/tracegrade/sqs/SqsClientConfig.java
+++ b/packages/backend/src/main/java/com/tracegrade/sqs/SqsClientConfig.java
@@ -1,0 +1,31 @@
+package com.tracegrade.sqs;
+
+import java.net.URI;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.SqsClientBuilder;
+
+@Configuration
+@ConditionalOnProperty(name = "sqs.enabled", havingValue = "true")
+public class SqsClientConfig {
+
+    @Bean
+    public SqsClient sqsClient(SqsProperties properties) {
+        SqsClientBuilder builder = SqsClient.builder()
+                .region(Region.of(properties.getRegion()))
+                .credentialsProvider(DefaultCredentialsProvider.create());
+
+        if (StringUtils.hasText(properties.getEndpoint())) {
+            builder.endpointOverride(URI.create(properties.getEndpoint()));
+        }
+
+        return builder.build();
+    }
+}

--- a/packages/backend/src/main/java/com/tracegrade/sqs/SqsProperties.java
+++ b/packages/backend/src/main/java/com/tracegrade/sqs/SqsProperties.java
@@ -1,0 +1,33 @@
+package com.tracegrade.sqs;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Data;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "sqs")
+public class SqsProperties {
+
+    /** Whether SQS-based async grading is enabled. Defaults to false (synchronous fallback). */
+    private boolean enabled = false;
+
+    /** URL of the main grading queue. */
+    private String queueUrl = "";
+
+    /** URL of the dead-letter queue for failed grading jobs. */
+    private String dlqUrl = "";
+
+    /** AWS region. */
+    private String region = "us-east-1";
+
+    /** Custom endpoint URL for LocalStack (leave blank for real AWS). */
+    private String endpoint = "";
+
+    /** Seconds a message is hidden from other consumers after being received. */
+    private int visibilityTimeoutSeconds = 300;
+
+    /** Maximum number of receive attempts before a message is sent to the DLQ. */
+    private int maxReceiveCount = 3;
+}

--- a/packages/backend/src/main/resources/application.yml
+++ b/packages/backend/src/main/resources/application.yml
@@ -123,6 +123,16 @@ openai:
 grading:
   confidence-threshold: ${GRADING_CONFIDENCE_THRESHOLD:0.80}
 
+# SQS Configuration (async grading queue)
+sqs:
+  enabled: ${SQS_ENABLED:false}
+  queue-url: ${SQS_QUEUE_URL:}
+  dlq-url: ${SQS_DLQ_URL:}
+  region: ${AWS_REGION:us-east-1}
+  endpoint: ${SQS_ENDPOINT:}
+  visibility-timeout-seconds: ${SQS_VISIBILITY_TIMEOUT:300}
+  max-receive-count: ${SQS_MAX_RECEIVE_COUNT:3}
+
 # Logging Configuration
 logging:
   level:


### PR DESCRIPTION
## Summary

- Add AWS SQS SDK dependency and a new `com.tracegrade.sqs` package (`SqsProperties`, `SqsClientConfig`, `GradingJobMessage`, `GradingJobPublisher`) — all gated behind `sqs.enabled=true` via `@ConditionalOnProperty`
- Introduce `GradingEnqueuedResponse` DTO and `GradingService.enqueueGrading()` — async path publishes to SQS; synchronous fallback used when SQS is not configured (local dev without Docker)
- Change `POST /api/submissions/{id}/grade` to return **202 Accepted** with `{ status: "QUEUED" | "COMPLETED" | "ALREADY_GRADED" }`
- Add `infra/localstack/init-sqs.sh` to provision the main grading queue and its DLQ via `awslocal`
- Update `docker-compose.yml`: enable `sqs` in LocalStack SERVICES, mount `init-sqs.sh`, inject SQS env vars into the backend container
- Add `sqs:` config block to `application.yml` (disabled by default; enabled via `SQS_ENABLED=true`)

## Test plan

- [ ] `docker-compose up localstack` → `awslocal sqs list-queues` shows `tracegrade-grading-queue` and `tracegrade-grading-dlq`
- [ ] `docker-compose up` → `POST /api/submissions/{id}/grade` returns 202 with `{"status":"QUEUED"}`; submission status in DB is `PENDING`
- [ ] `GET /api/submissions/{id}/grade` returns 404 (result not yet produced — worker is FEAT-020)
- [ ] Without Docker (`sqs.enabled=false`): `POST /api/submissions/{id}/grade` returns 202 with `{"status":"COMPLETED"}` (synchronous fallback intact)
- [ ] Re-posting an already-graded submission returns 202 with `{"status":"ALREADY_GRADED"}`

## Notes

`GradingService.grade()` is preserved for the upcoming FEAT-020 grading worker, which will consume from this queue and call it directly.