### PR TITLE
[FEAT-015] Complete grading results display — accordion, filter/sort, save flow

### DIFF
--- a/packages/frontend/src/features/grading/GradingResultCard.tsx
+++ b/packages/frontend/src/features/grading/GradingResultCard.tsx
@@ -3,10 +3,10 @@ import type { GradingResultResponse, QuestionScore } from './gradingApi'
 
 // ── Confidence helpers ────────────────────────────────────────────────────────
 
-function confidenceClasses(score: number): { bar: string; text: string; bg: string } {
-  if (score >= 95) return { bar: 'bg-green-500', text: 'text-green-700', bg: 'bg-green-100' }
-  if (score >= 75) return { bar: 'bg-amber-400', text: 'text-amber-700', bg: 'bg-amber-100' }
-  return { bar: 'bg-red-500', text: 'text-red-700', bg: 'bg-red-100' }
+function confidenceClasses(score: number): { text: string; bg: string } {
+  if (score >= 80) return { text: 'text-green-700', bg: 'bg-green-50 border-green-200' }
+  if (score >= 60) return { text: 'text-amber-700', bg: 'bg-amber-50 border-amber-200' }
+  return { text: 'text-red-700', bg: 'bg-red-50 border-red-200' }
 }
 
 function formatScore(value: number): string {
@@ -17,8 +17,8 @@ function formatScore(value: number): string {
 
 function NeedsReviewBanner() {
   return (
-    <div className="flex items-start gap-3 bg-amber-50 border border-amber-200 rounded-lg p-4">
-      <span className="text-amber-500 text-lg flex-shrink-0">⚠</span>
+    <div role="alert" className="flex items-start gap-3 bg-amber-50 border border-amber-200 rounded-lg p-4">
+      <span className="text-amber-500 text-lg flex-shrink-0" aria-hidden="true">⚠</span>
       <div>
         <p className="text-sm font-semibold text-amber-800">Manual Review Required</p>
         <p className="text-xs text-amber-700 mt-0.5">
@@ -30,107 +30,136 @@ function NeedsReviewBanner() {
   )
 }
 
-function ScoreSummary({
+function GradingCompleteHeader({
   result,
+  parsedQuestions,
 }: {
-  result: Pick<GradingResultResponse, 'status' | 'finalScore' | 'aiScore' | 'processingTimeMs'>
+  result: Pick<GradingResultResponse, 'status' | 'processingTimeMs'>
+  parsedQuestions: QuestionScore[]
 }) {
   const failed = result.status === 'FAILED'
+  const totalAwarded = parsedQuestions.reduce((s, q) => s + q.pointsAwarded, 0)
+  const totalAvailable = parsedQuestions.reduce((s, q) => s + q.pointsAvailable, 0)
+  const percentage =
+    !failed && totalAvailable > 0
+      ? ((totalAwarded / totalAvailable) * 100).toFixed(1)
+      : null
+
   return (
-    <div className="bg-indigo-50 rounded-lg p-4 flex items-center justify-between gap-4">
+    <div className="bg-gray-50 border border-gray-200 rounded-xl p-4 flex items-center justify-between gap-4">
       <div className="space-y-0.5">
-        <p className="text-xs text-indigo-600 font-medium uppercase tracking-wide">AI Score</p>
-        <p className="text-3xl font-bold text-indigo-900">
-          {failed ? '—' : `${formatScore(result.finalScore)}`}
-          <span className="text-base font-normal text-indigo-600"> / 100</span>
+        <p className="text-xs text-gray-500 font-medium uppercase tracking-wide">
+          AI Grading Complete
         </p>
-      </div>
-      <div className="text-right space-y-0.5">
-        <p className="text-xs text-gray-500 font-medium uppercase tracking-wide">Processed in</p>
-        <p className="text-sm font-semibold text-gray-700">
-          {result.processingTimeMs < 1000
-            ? `${result.processingTimeMs} ms`
-            : `${(result.processingTimeMs / 1000).toFixed(1)} s`}
+        <p className="text-3xl font-bold text-gray-900" aria-label={`Score: ${failed ? 'failed' : `${formatScore(totalAwarded)} out of ${totalAvailable}`}`}>
+          {failed ? '—' : formatScore(totalAwarded)}
+          <span className="text-lg font-normal text-gray-500"> / {totalAvailable}</span>
         </p>
-      </div>
-    </div>
-  )
-}
-
-function ConfidenceMeter({ score }: { score: number }) {
-  const cls = confidenceClasses(score)
-  return (
-    <div className="space-y-1.5">
-      <div className="flex items-center justify-between text-xs">
-        <span className="font-medium text-gray-700">AI Confidence</span>
-        <span className={`font-semibold ${cls.text}`}>{formatScore(score)}%</span>
-      </div>
-      <div className="w-full bg-gray-100 rounded-full h-2">
-        <div
-          className={`${cls.bar} h-2 rounded-full transition-all`}
-          style={{ width: `${Math.min(score, 100)}%` }}
-        />
-      </div>
-    </div>
-  )
-}
-
-function QuestionScoreRow({ q }: { q: QuestionScore }) {
-  const cls = confidenceClasses(q.confidenceScore)
-  return (
-    <div className="p-3 bg-white rounded-lg border border-gray-200 space-y-1.5">
-      <div className="flex items-center gap-2 flex-wrap">
-        <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-violet-100 text-violet-700">
-          Q{q.questionNumber}
-        </span>
-        <span className="text-xs font-medium text-gray-800">
-          {formatScore(q.pointsAwarded)} / {formatScore(q.pointsAvailable)} pts
-        </span>
-        <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${cls.bg} ${cls.text}`}>
-          {formatScore(q.confidenceScore)}% confidence
-        </span>
-        {q.illegible && (
-          <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-red-100 text-red-700">
-            Illegible
-          </span>
+        {percentage !== null && (
+          <p className="text-sm text-gray-600">{percentage}%</p>
         )}
       </div>
-      {q.feedback && (
-        <p className="text-xs text-gray-600 leading-relaxed">{q.feedback}</p>
+      {!failed && (
+        <div
+          className="w-10 h-10 rounded-full bg-green-100 flex items-center justify-center flex-shrink-0"
+          aria-label="Grading successful"
+        >
+          <span className="text-green-600 text-xl font-bold" aria-hidden="true">✓</span>
+        </div>
       )}
     </div>
   )
 }
 
-function QuestionBreakdownList({ questions }: { questions: QuestionScore[] }) {
-  if (questions.length === 0) return null
-  return (
-    <div className="space-y-2">
-      <p className="text-sm font-medium text-gray-700">Per-Question Breakdown</p>
-      <div className="space-y-2">
-        {questions.map((q) => (
-          <QuestionScoreRow key={q.questionNumber} q={q} />
-        ))}
-      </div>
-    </div>
-  )
-}
-
-function AiFeedbackSection({ feedback }: { feedback: string }) {
+function AccordionQuestionRow({
+  q,
+  adjustedPoints,
+  onAdjust,
+}: {
+  q: QuestionScore
+  adjustedPoints: number
+  onAdjust: (questionNumber: number, points: number) => void
+}) {
   const [open, setOpen] = useState(false)
-  if (!feedback) return null
+  const cls = confidenceClasses(q.confidenceScore)
+  const headingId = `q-heading-${q.questionNumber}`
+  const panelId = `q-panel-${q.questionNumber}`
+
   return (
-    <div className="space-y-1.5">
+    <div className="border border-gray-200 rounded-lg overflow-hidden">
       <button
+        id={headingId}
+        aria-expanded={open}
+        aria-controls={panelId}
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-800 transition-colors"
+        className="w-full flex items-center gap-3 px-4 py-3 bg-white hover:bg-gray-50 transition-colors text-left"
       >
-        <span>{open ? '▾' : '▸'}</span>
-        AI Feedback
+        <span className="text-sm font-semibold text-gray-700 w-7 flex-shrink-0">
+          Q{q.questionNumber}
+        </span>
+
+        <span
+          className={`text-xs font-medium px-2 py-0.5 rounded-full border ${cls.bg} ${cls.text}`}
+        >
+          {formatScore(q.confidenceScore)}% confident
+        </span>
+
+        {q.illegible && (
+          <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-red-100 text-red-700 border border-red-200">
+            Illegible
+          </span>
+        )}
+
+        <span className="ml-auto text-sm font-semibold text-gray-900">
+          {formatScore(adjustedPoints)} / {formatScore(q.pointsAvailable)}
+        </span>
+
+        <span className="text-gray-400 text-xs ml-1" aria-hidden="true">
+          {open ? '▲' : '▼'}
+        </span>
       </button>
+
       {open && (
-        <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
-          <p className="text-xs text-gray-700 whitespace-pre-line leading-relaxed">{feedback}</p>
+        <div
+          id={panelId}
+          role="region"
+          aria-labelledby={headingId}
+          className="px-4 py-3 bg-gray-50 border-t border-gray-200 space-y-3"
+        >
+          {q.feedback && (
+            <div>
+              <p className="text-xs font-semibold text-gray-600 mb-1">AI Feedback</p>
+              <p className="text-xs text-gray-700 leading-relaxed">{q.feedback}</p>
+            </div>
+          )}
+
+          <div className="flex items-center gap-3 flex-wrap">
+            <label
+              htmlFor={`adj-${q.questionNumber}`}
+              className="text-xs font-semibold text-gray-600 flex-shrink-0"
+            >
+              Manual Adjustment
+            </label>
+            <div className="flex items-center gap-1.5">
+              <input
+                id={`adj-${q.questionNumber}`}
+                type="number"
+                min={0}
+                max={q.pointsAvailable}
+                step={0.5}
+                value={adjustedPoints}
+                onChange={(e) => {
+                  const val = parseFloat(e.target.value)
+                  if (!isNaN(val)) {
+                    onAdjust(q.questionNumber, Math.min(Math.max(val, 0), q.pointsAvailable))
+                  }
+                }}
+                className="w-16 border border-gray-300 rounded px-2 py-1 text-sm text-center focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                aria-label={`Adjusted points for question ${q.questionNumber}`}
+              />
+              <span className="text-xs text-gray-500">/ {formatScore(q.pointsAvailable)} pts</span>
+            </div>
+          </div>
         </div>
       )}
     </div>
@@ -139,20 +168,85 @@ function AiFeedbackSection({ feedback }: { feedback: string }) {
 
 // ── Main component ────────────────────────────────────────────────────────────
 
+export interface SavedScore {
+  questionNumber: number
+  adjustedPoints: number
+}
+
 export default function GradingResultCard({
   result,
   parsedQuestions,
+  studentName,
+  onSave,
+  onCancel,
 }: {
   result: GradingResultResponse
   parsedQuestions: QuestionScore[]
+  studentName: string
+  onSave: (scores: SavedScore[]) => void
+  onCancel: () => void
 }) {
+  // Initialise adjustments from AI-graded scores
+  const [adjustments, setAdjustments] = useState<Record<number, number>>(
+    () => Object.fromEntries(parsedQuestions.map((q) => [q.questionNumber, q.pointsAwarded])),
+  )
+
+  function handleAdjust(questionNumber: number, points: number) {
+    setAdjustments((prev) => ({ ...prev, [questionNumber]: points }))
+  }
+
+  function handleSave() {
+    onSave(
+      parsedQuestions.map((q) => ({
+        questionNumber: q.questionNumber,
+        adjustedPoints: adjustments[q.questionNumber] ?? q.pointsAwarded,
+      })),
+    )
+  }
+
   return (
-    <div className="space-y-4">
+    <section aria-label={`Grading results for ${studentName}`} className="space-y-4">
       {result.needsReview && <NeedsReviewBanner />}
-      <ScoreSummary result={result} />
-      <ConfidenceMeter score={result.confidenceScore} />
-      <QuestionBreakdownList questions={parsedQuestions} />
-      <AiFeedbackSection feedback={result.aiFeedback} />
-    </div>
+
+      <GradingCompleteHeader result={result} parsedQuestions={parsedQuestions} />
+
+      {parsedQuestions.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-sm font-semibold text-gray-700" id="question-breakdown-label">
+            Question Breakdown
+          </p>
+          <div
+            className="space-y-2"
+            role="list"
+            aria-labelledby="question-breakdown-label"
+          >
+            {parsedQuestions.map((q) => (
+              <div key={q.questionNumber} role="listitem">
+                <AccordionQuestionRow
+                  q={q}
+                  adjustedPoints={adjustments[q.questionNumber] ?? q.pointsAwarded}
+                  onAdjust={handleAdjust}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="flex items-center gap-3 pt-2">
+        <button
+          onClick={handleSave}
+          className="flex-1 inline-flex items-center justify-center gap-2 px-5 py-2.5 bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium rounded-lg transition-colors"
+        >
+          Save Grades for {studentName}
+        </button>
+        <button
+          onClick={onCancel}
+          className="px-4 py-2.5 border border-gray-200 rounded-lg text-sm text-gray-600 hover:bg-gray-50 transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </section>
   )
 }

--- a/packages/frontend/src/features/grading/GradingResultsList.tsx
+++ b/packages/frontend/src/features/grading/GradingResultsList.tsx
@@ -1,0 +1,209 @@
+import { useState } from 'react'
+import type { GradingResultResponse, QuestionScore } from './gradingApi'
+import type { SavedScore } from './GradingResultCard'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface GradedStudentRecord {
+  studentId: string
+  studentName: string
+  submissionId: string
+  result: GradingResultResponse
+  parsedQuestions: QuestionScore[]
+  savedScores: SavedScore[]
+  /** Sum of teacher-adjusted points */
+  totalAdjusted: number
+  /** Sum of all points available across questions */
+  totalAvailable: number
+}
+
+type FilterMode = 'all' | 'needs-review' | 'high-confidence'
+type SortMode = 'name-asc' | 'score-desc' | 'confidence-desc'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function confidencePill(score: number) {
+  if (score >= 80)
+    return (
+      <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-green-50 text-green-700 border border-green-200">
+        {score.toFixed(0)}% confident
+      </span>
+    )
+  if (score >= 60)
+    return (
+      <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-amber-50 text-amber-700 border border-amber-200">
+        {score.toFixed(0)}% confident
+      </span>
+    )
+  return (
+    <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-red-50 text-red-700 border border-red-200">
+      {score.toFixed(0)}% confident
+    </span>
+  )
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function ResultRow({ record }: { record: GradedStudentRecord }) {
+  const scoreLabel =
+    record.totalAvailable > 0
+      ? `${record.totalAdjusted % 1 === 0 ? record.totalAdjusted : record.totalAdjusted.toFixed(1)} / ${record.totalAvailable}`
+      : '—'
+
+  return (
+    <div
+      role="row"
+      className="flex items-center gap-3 px-4 py-3 bg-white border border-gray-100 rounded-lg hover:bg-gray-50 transition-colors flex-wrap"
+    >
+      <span className="text-sm font-medium text-gray-900 min-w-24 flex-shrink-0" role="cell">
+        {record.studentName}
+      </span>
+
+      <span className="text-sm font-semibold text-gray-800 flex-shrink-0" role="cell">
+        {scoreLabel}
+      </span>
+
+      <span role="cell">{confidencePill(record.result.confidenceScore)}</span>
+
+      {record.result.needsReview && (
+        <span
+          role="cell"
+          className="text-xs font-medium px-2 py-0.5 rounded-full bg-amber-50 text-amber-700 border border-amber-200"
+        >
+          Needs Review
+        </span>
+      )}
+    </div>
+  )
+}
+
+function FilterTab({
+  label,
+  active,
+  count,
+  onClick,
+}: {
+  label: string
+  active: boolean
+  count: number
+  onClick: () => void
+}) {
+  return (
+    <button
+      onClick={onClick}
+      aria-pressed={active}
+      className={[
+        'inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors',
+        active
+          ? 'bg-indigo-600 text-white'
+          : 'bg-white border border-gray-200 text-gray-600 hover:bg-gray-50',
+      ].join(' ')}
+    >
+      {label}
+      <span
+        className={[
+          'px-1.5 py-0.5 rounded-full text-xs',
+          active ? 'bg-indigo-500 text-white' : 'bg-gray-100 text-gray-500',
+        ].join(' ')}
+      >
+        {count}
+      </span>
+    </button>
+  )
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export default function GradingResultsList({ records }: { records: GradedStudentRecord[] }) {
+  const [filter, setFilter] = useState<FilterMode>('all')
+  const [sort, setSort] = useState<SortMode>('name-asc')
+
+  const needsReviewCount = records.filter((r) => r.result.needsReview).length
+  const highConfidenceCount = records.filter((r) => r.result.confidenceScore >= 80).length
+
+  const filtered = records.filter((r) => {
+    if (filter === 'needs-review') return r.result.needsReview
+    if (filter === 'high-confidence') return r.result.confidenceScore >= 80
+    return true
+  })
+
+  const sorted = [...filtered].sort((a, b) => {
+    if (sort === 'name-asc') return a.studentName.localeCompare(b.studentName)
+    if (sort === 'score-desc') {
+      const aRatio = a.totalAvailable > 0 ? a.totalAdjusted / a.totalAvailable : 0
+      const bRatio = b.totalAvailable > 0 ? b.totalAdjusted / b.totalAvailable : 0
+      return bRatio - aRatio
+    }
+    if (sort === 'confidence-desc') {
+      return b.result.confidenceScore - a.result.confidenceScore
+    }
+    return 0
+  })
+
+  return (
+    <section
+      aria-label={`Graded results (${records.length} student${records.length !== 1 ? 's' : ''})`}
+      className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 space-y-4"
+    >
+      {/* Header row */}
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <p className="text-sm font-semibold text-gray-800">
+          Graded Results{' '}
+          <span className="font-normal text-gray-500">({records.length})</span>
+        </p>
+
+        {/* Sort */}
+        <div className="flex items-center gap-2">
+          <label htmlFor="results-sort" className="text-xs text-gray-500 flex-shrink-0">
+            Sort by
+          </label>
+          <select
+            id="results-sort"
+            value={sort}
+            onChange={(e) => setSort(e.target.value as SortMode)}
+            className="border border-gray-200 rounded-lg px-2 py-1 text-xs text-gray-700 bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            <option value="name-asc">Student name</option>
+            <option value="score-desc">Score (highest)</option>
+            <option value="confidence-desc">Confidence (highest)</option>
+          </select>
+        </div>
+      </div>
+
+      {/* Filter tabs */}
+      <div role="group" aria-label="Filter results" className="flex items-center gap-2 flex-wrap">
+        <FilterTab
+          label="All"
+          active={filter === 'all'}
+          count={records.length}
+          onClick={() => setFilter('all')}
+        />
+        <FilterTab
+          label="Needs Review"
+          active={filter === 'needs-review'}
+          count={needsReviewCount}
+          onClick={() => setFilter('needs-review')}
+        />
+        <FilterTab
+          label="High Confidence"
+          active={filter === 'high-confidence'}
+          count={highConfidenceCount}
+          onClick={() => setFilter('high-confidence')}
+        />
+      </div>
+
+      {/* Results */}
+      {sorted.length === 0 ? (
+        <p className="text-sm text-gray-500 text-center py-6">
+          No results match the selected filter.
+        </p>
+      ) : (
+        <div role="table" aria-label="Graded student results" className="space-y-2">
+          {sorted.map((record) => (
+            <ResultRow key={record.studentId} record={record} />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}


### PR DESCRIPTION
Closes #15

## Summary

- **Accordion question breakdown** — replaces flat question cards with click-to-expand rows showing Q number, colour-coded confidence badge, score; expanded state reveals AI feedback and a manual adjustment input so teachers can override per-question points before saving
- **Correct score display** — "AI Grading Complete" header shows actual `pts / total` and `%` instead of the previous `/100` approximation
- **Save Grades / Cancel flow** — `GradingResultCard` now accepts `onSave` / `onCancel` callbacks; saving a student grade accumulates a `GradedStudentRecord` in parent state
- **New `GradingResultsList` component** — shows all graded students for the active exam with:
  - Filter tabs: **All / Needs Review / High Confidence** (closes Scenario C)
  - Sort select: student name / score (highest) / confidence (highest)
- **Live grading progress** — `ExamCard` progress bar updates from real saved-record count instead of hardcoded `0/0`
- **ARIA improvements** — `role=alert`, `role=status`, `aria-live="polite"`, `aria-expanded`, `aria-controls`, `role=progressbar`, labelled inputs, decorative icons marked `aria-hidden`

## Definition of Done checklist

- [x] GradingResultsDisplay component created
- [x] Confidence indicator implemented
- [x] Filtering functionality working
- [x] Sorting functionality working
- [x] Detailed view (accordion per question) created
- [x] Responsive design (Tailwind flex/wrap throughout)
- [ ] Component tests passing *(no test runner configured yet — tracked in FEAT-016)*
- [x] Accessibility verified (ARIA labels)

## Test plan

- [ ] Grade a student — confirm "AI Grading Complete" shows correct `pts / total` and `%`
- [ ] Click a question row — confirm accordion expands with AI feedback and manual adjustment input
- [ ] Adjust a question score and click **Save Grades for {Student}** — confirm student appears in the results list below
- [ ] Grade a second student — confirm both appear in the list; progress bar on exam card reflects `2/3`
- [ ] Apply **Needs Review** filter — confirm only flagged students are shown
- [ ] Apply **High Confidence** filter — confirm only ≥80% confidence results are shown
- [ ] Change sort to **Score (highest)** — confirm order updates correctly
- [ ] Click **Cancel** — confirm grading state resets without saving