### PR TITLE
feat: Implement School Entity with Multi-Tenant Architecture [FEAT-021]

### DIFF
--- a/packages/backend/src/main/java/com/tracegrade/domain/model/School.java
+++ b/packages/backend/src/main/java/com/tracegrade/domain/model/School.java
@@ -1,0 +1,58 @@
+package com.tracegrade.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "schools")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class School extends BaseEntity {
+
+    @NotBlank
+    @Size(max = 200)
+    @Column(name = "name", nullable = false, length = 200)
+    private String name;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "school_type", nullable = false, length = 20)
+    private SchoolType schoolType;
+
+    @Size(max = 500)
+    @Column(name = "address", length = 500)
+    private String address;
+
+    @Size(max = 20)
+    @Column(name = "phone", length = 20)
+    private String phone;
+
+    @Email
+    @Size(max = 200)
+    @Column(name = "email", length = 200)
+    private String email;
+
+    @Size(max = 100)
+    @Column(name = "timezone", length = 100)
+    private String timezone;
+
+    @NotNull
+    @Column(name = "is_active", nullable = false)
+    @Builder.Default
+    private Boolean isActive = true;
+}

--- a/packages/backend/src/main/java/com/tracegrade/domain/model/SchoolType.java
+++ b/packages/backend/src/main/java/com/tracegrade/domain/model/SchoolType.java
@@ -1,0 +1,9 @@
+package com.tracegrade.domain.model;
+
+public enum SchoolType {
+    ELEMENTARY,
+    MIDDLE,
+    HIGH,
+    UNIVERSITY,
+    OTHER
+}

--- a/packages/backend/src/main/java/com/tracegrade/domain/repository/SchoolRepository.java
+++ b/packages/backend/src/main/java/com/tracegrade/domain/repository/SchoolRepository.java
@@ -1,0 +1,19 @@
+package com.tracegrade.domain.repository;
+
+import com.tracegrade.domain.model.School;
+import com.tracegrade.domain.model.SchoolType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface SchoolRepository extends JpaRepository<School, UUID> {
+
+    List<School> findByIsActiveTrue();
+
+    List<School> findBySchoolTypeAndIsActiveTrue(SchoolType schoolType);
+
+    boolean existsByNameIgnoreCase(String name);
+}

--- a/packages/backend/src/main/java/com/tracegrade/dto/request/CreateSchoolRequest.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/request/CreateSchoolRequest.java
@@ -1,0 +1,40 @@
+package com.tracegrade.dto.request;
+
+import com.tracegrade.domain.model.SchoolType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateSchoolRequest {
+
+    @NotBlank
+    @Size(max = 200)
+    private String name;
+
+    @NotNull
+    private SchoolType schoolType;
+
+    @Size(max = 500)
+    private String address;
+
+    @Size(max = 20)
+    private String phone;
+
+    @Email
+    @Size(max = 200)
+    private String email;
+
+    @Size(max = 100)
+    private String timezone;
+}

--- a/packages/backend/src/main/java/com/tracegrade/dto/request/UpdateSchoolRequest.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/request/UpdateSchoolRequest.java
@@ -1,0 +1,38 @@
+package com.tracegrade.dto.request;
+
+import com.tracegrade.domain.model.SchoolType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateSchoolRequest {
+
+    @Size(max = 200)
+    private String name;
+
+    private SchoolType schoolType;
+
+    @Size(max = 500)
+    private String address;
+
+    @Size(max = 20)
+    private String phone;
+
+    @Email
+    @Size(max = 200)
+    private String email;
+
+    @Size(max = 100)
+    private String timezone;
+
+    private Boolean isActive;
+}

--- a/packages/backend/src/main/java/com/tracegrade/dto/response/SchoolResponse.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/response/SchoolResponse.java
@@ -1,0 +1,28 @@
+package com.tracegrade.dto.response;
+
+import com.tracegrade.domain.model.SchoolType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SchoolResponse {
+
+    private UUID id;
+    private String name;
+    private SchoolType schoolType;
+    private String address;
+    private String phone;
+    private String email;
+    private String timezone;
+    private Boolean isActive;
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/packages/backend/src/main/java/com/tracegrade/school/SchoolController.java
+++ b/packages/backend/src/main/java/com/tracegrade/school/SchoolController.java
@@ -1,0 +1,96 @@
+package com.tracegrade.school;
+
+import com.tracegrade.domain.model.SchoolType;
+import com.tracegrade.dto.request.CreateSchoolRequest;
+import com.tracegrade.dto.request.UpdateSchoolRequest;
+import com.tracegrade.dto.response.ApiResponse;
+import com.tracegrade.dto.response.SchoolResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/schools")
+@RequiredArgsConstructor
+@Validated
+public class SchoolController {
+
+    private final SchoolService schoolService;
+
+    /**
+     * List all active schools, optionally filtered by type.
+     *
+     * GET /api/schools
+     * GET /api/schools?type=HIGH
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<SchoolResponse>>> getSchools(
+            @RequestParam(required = false) SchoolType type) {
+
+        List<SchoolResponse> schools = type != null
+                ? schoolService.getSchoolsByType(type)
+                : schoolService.getAllActiveSchools();
+
+        return ResponseEntity.ok(ApiResponse.success(schools));
+    }
+
+    /**
+     * Retrieve a single school by ID.
+     *
+     * GET /api/schools/{id}
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<SchoolResponse>> getSchool(@PathVariable UUID id) {
+        return ResponseEntity.ok(ApiResponse.success(schoolService.getSchoolById(id)));
+    }
+
+    /**
+     * Create a new school.
+     *
+     * POST /api/schools
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<SchoolResponse>> createSchool(
+            @Valid @RequestBody CreateSchoolRequest request) {
+
+        SchoolResponse response = schoolService.createSchool(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /**
+     * Partially update a school's details.
+     *
+     * PATCH /api/schools/{id}
+     */
+    @PatchMapping("/{id}")
+    public ResponseEntity<ApiResponse<SchoolResponse>> updateSchool(
+            @PathVariable UUID id,
+            @Valid @RequestBody UpdateSchoolRequest request) {
+
+        return ResponseEntity.ok(ApiResponse.success(schoolService.updateSchool(id, request)));
+    }
+
+    /**
+     * Soft-delete a school by marking it inactive.
+     *
+     * DELETE /api/schools/{id}
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deactivateSchool(@PathVariable UUID id) {
+        schoolService.deactivateSchool(id);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/packages/backend/src/main/java/com/tracegrade/school/SchoolService.java
+++ b/packages/backend/src/main/java/com/tracegrade/school/SchoolService.java
@@ -1,0 +1,104 @@
+package com.tracegrade.school;
+
+import com.tracegrade.domain.model.School;
+import com.tracegrade.domain.model.SchoolType;
+import com.tracegrade.domain.repository.SchoolRepository;
+import com.tracegrade.dto.request.CreateSchoolRequest;
+import com.tracegrade.dto.request.UpdateSchoolRequest;
+import com.tracegrade.dto.response.SchoolResponse;
+import com.tracegrade.exception.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@SuppressWarnings("null") // UUID path params are guaranteed non-null by Spring MVC before reaching findById()
+public class SchoolService {
+
+    private final SchoolRepository schoolRepository;
+
+    @Transactional(readOnly = true)
+    public List<SchoolResponse> getAllActiveSchools() {
+        return schoolRepository.findByIsActiveTrue().stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<SchoolResponse> getSchoolsByType(SchoolType schoolType) {
+        return schoolRepository.findBySchoolTypeAndIsActiveTrue(schoolType).stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public SchoolResponse getSchoolById(UUID id) {
+        return toResponse(findById(id));
+    }
+
+    @Transactional
+    public SchoolResponse createSchool(CreateSchoolRequest request) {
+        School school = School.builder()
+                .name(request.getName())
+                .schoolType(request.getSchoolType())
+                .address(request.getAddress())
+                .phone(request.getPhone())
+                .email(request.getEmail())
+                .timezone(request.getTimezone())
+                .build();
+
+        log.info("Creating school: name={}, type={}", request.getName(), request.getSchoolType());
+        return toResponse(schoolRepository.save(school));
+    }
+
+    @Transactional
+    public SchoolResponse updateSchool(UUID id, UpdateSchoolRequest request) {
+        School school = findById(id);
+
+        if (request.getName() != null) school.setName(request.getName());
+        if (request.getSchoolType() != null) school.setSchoolType(request.getSchoolType());
+        if (request.getAddress() != null) school.setAddress(request.getAddress());
+        if (request.getPhone() != null) school.setPhone(request.getPhone());
+        if (request.getEmail() != null) school.setEmail(request.getEmail());
+        if (request.getTimezone() != null) school.setTimezone(request.getTimezone());
+        if (request.getIsActive() != null) school.setIsActive(request.getIsActive());
+
+        log.info("Updating school {}", id);
+        return toResponse(schoolRepository.save(school));
+    }
+
+    @Transactional
+    public void deactivateSchool(UUID id) {
+        School school = findById(id);
+        log.info("Deactivating school {}", id);
+        school.setIsActive(false);
+        schoolRepository.save(school);
+    }
+
+    private School findById(UUID id) {
+        return schoolRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("School", id));
+    }
+
+    private SchoolResponse toResponse(School school) {
+        return SchoolResponse.builder()
+                .id(school.getId())
+                .name(school.getName())
+                .schoolType(school.getSchoolType())
+                .address(school.getAddress())
+                .phone(school.getPhone())
+                .email(school.getEmail())
+                .timezone(school.getTimezone())
+                .isActive(school.getIsActive())
+                .createdAt(school.getCreatedAt())
+                .updatedAt(school.getUpdatedAt())
+                .build();
+    }
+}

--- a/packages/backend/src/main/resources/db/migration/V3__add_school_entity.sql
+++ b/packages/backend/src/main/resources/db/migration/V3__add_school_entity.sql
@@ -1,0 +1,19 @@
+-- FEAT-021: Add School entity for multi-tenant architecture
+
+CREATE TABLE schools (
+    id UUID PRIMARY KEY,
+    name VARCHAR(200) NOT NULL,
+    school_type VARCHAR(20) NOT NULL,
+    address VARCHAR(500),
+    phone VARCHAR(20),
+    email VARCHAR(200),
+    timezone VARCHAR(100),
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);
+
+-- school_id will be added to users table when User entity is implemented (Phase 2 of FEAT-021)
+
+CREATE INDEX idx_schools_type_active ON schools(school_type, is_active);
+CREATE INDEX idx_schools_is_active ON schools(is_active);


### PR DESCRIPTION
## Summary

- Introduces `School` entity and `SchoolType` enum as the foundation for multi-tenant support (ADR-002)
- Adds Flyway migration V3 to create the `schools` table with soft-delete and performance indexes
- Implements full CRUD via `SchoolService` + REST endpoints at `/api/schools` via `SchoolController`
- Adds `CreateSchoolRequest`, `UpdateSchoolRequest`, and `SchoolResponse` DTOs following existing patterns

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/schools` | List active schools (optional `?type=HIGH`) |
| `GET` | `/api/schools/{id}` | Get school by ID |
| `POST` | `/api/schools` | Create a school |
| `PATCH` | `/api/schools/{id}` | Partial update |
| `DELETE` | `/api/schools/{id}` | Soft-delete (sets `is_active = false`) |

## Notes

- `school_id` FK on the `users` table is deferred to Phase 2 of FEAT-021 — will be added in a separate migration once the User entity is implemented
- Existing users/data are unaffected (no existing tables modified)

## Test plan

- [ ] Apply migration against local Postgres and verify `schools` table is created
- [ ] `POST /api/schools` — create a school, verify response and DB row
- [ ] `GET /api/schools` — returns only active schools
- [ ] `GET /api/schools?type=HIGH` — filters by type correctly
- [ ] `GET /api/schools/{id}` — returns 200 for valid ID, 404 for unknown
- [ ] `PATCH /api/schools/{id}` — partial update (only sent fields change)
- [ ] `DELETE /api/schools/{id}` — school marked inactive, still present in DB
- [ ] Verify invalid `schoolType` enum value returns 400

Closes #21