### PR TITLE
[FEAT-009] Set Up API Documentation with Swagger/OpenAPI

### DIFF
--- a/packages/backend/pom.xml
+++ b/packages/backend/pom.xml
@@ -131,6 +131,13 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- SpringDoc OpenAPI (Swagger UI + OpenAPI 3.1 spec) -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+
         <!-- OWASP Java HTML Sanitizer for XSS prevention -->
         <dependency>
             <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>

--- a/packages/backend/src/main/java/com/tracegrade/config/CsrfTokenController.java
+++ b/packages/backend/src/main/java/com/tracegrade/config/CsrfTokenController.java
@@ -1,5 +1,6 @@
 package com.tracegrade.config;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
  * The actual token is delivered via the XSRF-TOKEN cookie (set by
  * {@link CsrfCookieFilter}), not in the response body.
  */
+@Hidden
 @RestController
 public class CsrfTokenController {
 

--- a/packages/backend/src/main/java/com/tracegrade/config/OpenApiConfig.java
+++ b/packages/backend/src/main/java/com/tracegrade/config/OpenApiConfig.java
@@ -1,0 +1,36 @@
+package com.tracegrade.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "TraceGrade API",
+                version = "0.1.0",
+                description = "REST API for TraceGrade — AI-powered exam grading and teacher productivity platform. "
+                        + "All protected endpoints require a JWT bearer token obtained via the authentication flow.",
+                contact = @Contact(
+                        name = "TraceGrade Team",
+                        url = "https://github.com/DanieBrown/TraceGrade"
+                )
+        ),
+        servers = {
+                @Server(url = "http://localhost:8080", description = "Local development")
+        }
+)
+@SecurityScheme(
+        name = "BearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        description = "JWT token obtained from the authentication endpoint. "
+                + "Pass as: Authorization: Bearer <token>"
+)
+public class OpenApiConfig {
+}

--- a/packages/backend/src/main/java/com/tracegrade/config/SecurityConfig.java
+++ b/packages/backend/src/main/java/com/tracegrade/config/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
             http.csrf(csrf -> csrf
                     .csrfTokenRepository(tokenRepository)
                     .csrfTokenRequestHandler(requestHandler)
-                    .ignoringRequestMatchers("/actuator/**")
+                    .ignoringRequestMatchers("/actuator/**", "/swagger-ui/**", "/v3/api-docs/**")
             );
 
             // Eagerly load deferred CSRF token so the cookie is set on every response
@@ -69,6 +69,7 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/actuator/**").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         .anyRequest().permitAll() // Will be restricted when auth is implemented
                 )
                 .exceptionHandling(ex -> ex

--- a/packages/backend/src/main/java/com/tracegrade/dto/request/CreateAnswerRubricRequest.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/request/CreateAnswerRubricRequest.java
@@ -3,6 +3,7 @@ package com.tracegrade.dto.request;
 import java.math.BigDecimal;
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
@@ -16,24 +17,32 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Request body for creating an answer rubric entry for one question in an exam template")
 public class CreateAnswerRubricRequest {
 
     // examTemplateId is provided via the URL path variable; this field is optional on the request body
+    @Schema(description = "UUID of the exam template (optional — taken from URL path when omitted)")
     private UUID examTemplateId;
 
     @NotNull(message = "Question number is required")
     @Positive(message = "Question number must be positive")
+    @Schema(description = "1-based question number, unique within the exam template", example = "3", requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer questionNumber;
 
+    @Schema(description = "Model answer text for this question", example = "The mitochondria is the powerhouse of the cell.")
     private String answerText;
 
+    @Schema(description = "URL of an image showing the model answer (e.g. a diagram)", example = "https://storage.example.com/rubrics/q3-diagram.png")
     private String answerImageUrl;
 
     @NotNull(message = "Points available is required")
     @Positive(message = "Points available must be positive")
+    @Schema(description = "Maximum points a student can earn for this question", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
     private BigDecimal pointsAvailable;
 
+    @Schema(description = "Comma-separated list of acceptable alternative answers", example = "powerhouse, energy factory")
     private String acceptableVariations;
 
+    @Schema(description = "Freeform grading notes visible only to teachers and the AI grader", example = "Award full marks if student mentions ATP production.")
     private String gradingNotes;
 }

--- a/packages/backend/src/main/java/com/tracegrade/dto/request/CreateSchoolRequest.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/request/CreateSchoolRequest.java
@@ -1,6 +1,7 @@
 package com.tracegrade.dto.request;
 
 import com.tracegrade.domain.model.SchoolType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -16,25 +17,32 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Request body for creating a new school")
 public class CreateSchoolRequest {
 
     @NotBlank
     @Size(max = 200)
+    @Schema(description = "Full display name of the school", example = "Springfield High School", requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     @NotNull
+    @Schema(description = "School classification type", example = "HIGH", requiredMode = Schema.RequiredMode.REQUIRED)
     private SchoolType schoolType;
 
     @Size(max = 500)
+    @Schema(description = "Physical address of the school", example = "742 Evergreen Terrace, Springfield")
     private String address;
 
     @Size(max = 20)
+    @Schema(description = "Contact phone number", example = "+1-555-0100")
     private String phone;
 
     @Email
     @Size(max = 200)
+    @Schema(description = "Contact email address", example = "admin@springfield-high.edu")
     private String email;
 
     @Size(max = 100)
+    @Schema(description = "IANA timezone identifier for the school", example = "America/New_York")
     private String timezone;
 }

--- a/packages/backend/src/main/java/com/tracegrade/dto/request/GradingReviewRequest.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/request/GradingReviewRequest.java
@@ -2,6 +2,7 @@ package com.tracegrade.dto.request;
 
 import java.math.BigDecimal;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
@@ -16,16 +17,21 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Request body for a teacher reviewing and optionally overriding an AI grading result")
 public class GradingReviewRequest {
 
     @NotNull(message = "Final score is required")
     @DecimalMin(value = "0", message = "Final score must be >= 0")
     @DecimalMax(value = "100", message = "Final score must be <= 100")
+    @Schema(description = "Teacher-confirmed final score as a percentage (0–100)", example = "85.5", requiredMode = Schema.RequiredMode.REQUIRED)
     private BigDecimal finalScore;
 
     @NotNull(message = "teacherOverride flag is required")
+    @Schema(description = "true if the teacher is overriding the AI score; false if confirming it", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean teacherOverride;
 
     /** Optional updated per-question scores JSON; when null the existing scores are kept */
+    @Schema(description = "Updated per-question scores as a JSON array; omit to keep the existing AI scores",
+            example = "[{\"question\":1,\"score\":4},{\"question\":2,\"score\":3}]")
     private String questionScores;
 }

--- a/packages/backend/src/main/java/com/tracegrade/dto/request/UpdateAnswerRubricRequest.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/request/UpdateAnswerRubricRequest.java
@@ -2,6 +2,7 @@ package com.tracegrade.dto.request;
 
 import java.math.BigDecimal;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,19 +15,26 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Request body for updating an existing answer rubric. Only provided fields are changed.")
 public class UpdateAnswerRubricRequest {
 
     @Positive(message = "Question number must be positive")
+    @Schema(description = "Updated 1-based question number", example = "4")
     private Integer questionNumber;
 
+    @Schema(description = "Updated model answer text", example = "The nucleus controls cell activity.")
     private String answerText;
 
+    @Schema(description = "Updated URL of the model answer image", example = "https://storage.example.com/rubrics/q4-diagram.png")
     private String answerImageUrl;
 
     @Positive(message = "Points available must be positive")
+    @Schema(description = "Updated maximum points for this question", example = "10")
     private BigDecimal pointsAvailable;
 
+    @Schema(description = "Updated list of acceptable alternative answers", example = "nucleus, control centre")
     private String acceptableVariations;
 
+    @Schema(description = "Updated grading notes for teachers and the AI grader", example = "Partial credit allowed for mentioning DNA storage.")
     private String gradingNotes;
 }

--- a/packages/backend/src/main/java/com/tracegrade/dto/request/UpdateSchoolRequest.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/request/UpdateSchoolRequest.java
@@ -1,6 +1,7 @@
 package com.tracegrade.dto.request;
 
 import com.tracegrade.domain.model.SchoolType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -14,25 +15,33 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "Request body for partially updating a school. Only provided fields are changed.")
 public class UpdateSchoolRequest {
 
     @Size(max = 200)
+    @Schema(description = "Updated display name of the school", example = "Springfield Academy")
     private String name;
 
+    @Schema(description = "Updated school classification type", example = "UNIVERSITY")
     private SchoolType schoolType;
 
     @Size(max = 500)
+    @Schema(description = "Updated physical address", example = "1 University Drive, Springfield")
     private String address;
 
     @Size(max = 20)
+    @Schema(description = "Updated contact phone number", example = "+1-555-0200")
     private String phone;
 
     @Email
     @Size(max = 200)
+    @Schema(description = "Updated contact email address", example = "info@springfield-academy.edu")
     private String email;
 
     @Size(max = 100)
+    @Schema(description = "Updated IANA timezone identifier", example = "America/Chicago")
     private String timezone;
 
+    @Schema(description = "Set to false to deactivate the school", example = "true")
     private Boolean isActive;
 }

--- a/packages/backend/src/main/java/com/tracegrade/dto/request/UpdateSubmissionStatusRequest.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/request/UpdateSubmissionStatusRequest.java
@@ -2,6 +2,7 @@ package com.tracegrade.dto.request;
 
 import com.tracegrade.domain.model.SubmissionStatus;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,8 +11,11 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Request body for updating the processing status of a student submission")
 public class UpdateSubmissionStatusRequest {
 
     @NotNull
+    @Schema(description = "New status for the submission", example = "PROCESSING", requiredMode = Schema.RequiredMode.REQUIRED,
+            allowableValues = {"PENDING", "PROCESSING", "COMPLETED", "FAILED"})
     private SubmissionStatus status;
 }

--- a/packages/backend/src/main/java/com/tracegrade/dto/response/AnswerRubricResponse.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/response/AnswerRubricResponse.java
@@ -4,21 +4,42 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "Answer rubric record for a single question in an exam template")
 public class AnswerRubricResponse {
 
+    @Schema(description = "Unique identifier of the rubric")
     private UUID id;
+
+    @Schema(description = "UUID of the exam template this rubric belongs to")
     private UUID examTemplateId;
+
+    @Schema(description = "1-based question number", example = "3")
     private Integer questionNumber;
+
+    @Schema(description = "Model answer text", example = "The mitochondria is the powerhouse of the cell.")
     private String answerText;
+
+    @Schema(description = "URL of the model answer image")
     private String answerImageUrl;
+
+    @Schema(description = "Maximum points available for this question", example = "5")
     private BigDecimal pointsAvailable;
+
+    @Schema(description = "Acceptable alternative answers", example = "powerhouse, energy factory")
     private String acceptableVariations;
+
+    @Schema(description = "Grading notes for teachers and the AI grader")
     private String gradingNotes;
+
+    @Schema(description = "UTC timestamp when the rubric was created")
     private Instant createdAt;
+
+    @Schema(description = "UTC timestamp of the last update")
     private Instant updatedAt;
 }

--- a/packages/backend/src/main/java/com/tracegrade/dto/response/ApiError.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/response/ApiError.java
@@ -3,6 +3,7 @@ package com.tracegrade.dto.response;
 import java.time.Instant;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,11 +11,19 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
+@Schema(description = "Error detail returned inside ApiResponse when success=false")
 public class ApiError {
 
+    @Schema(description = "Machine-readable error code", example = "VALIDATION_ERROR")
     private final String code;
+
+    @Schema(description = "Human-readable error description", example = "Request validation failed")
     private final String message;
+
+    @Schema(description = "Per-field validation errors; present only for 400 responses")
     private final List<FieldError> details;
+
+    @Schema(description = "UTC timestamp when the error occurred", example = "2024-01-15T10:30:00Z")
     private final Instant timestamp;
 
     public static ApiError of(String code, String message) {

--- a/packages/backend/src/main/java/com/tracegrade/dto/response/ApiResponse.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/response/ApiResponse.java
@@ -2,6 +2,7 @@ package com.tracegrade.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,10 +11,16 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Standard API envelope returned by all endpoints")
 public class ApiResponse<T> {
 
+    @Schema(description = "true when the request succeeded, false on error", example = "true")
     private final boolean success;
+
+    @Schema(description = "Response payload; present only on success")
     private final T data;
+
+    @Schema(description = "Error detail; present only on failure")
     private final ApiError error;
 
     public static <T> ApiResponse<T> success(T data) {

--- a/packages/backend/src/main/java/com/tracegrade/dto/response/BatchUploadResponse.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/response/BatchUploadResponse.java
@@ -2,14 +2,21 @@ package com.tracegrade.dto.response;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "Result of a batch exam file upload operation")
 public class BatchUploadResponse {
 
+    @Schema(description = "Per-file upload results")
     private List<FileUploadResponse> submissions;
+
+    @Schema(description = "Total number of files submitted in the request", example = "5")
     private int totalFiles;
+
+    @Schema(description = "Number of files successfully stored", example = "5")
     private int successfulUploads;
 }

--- a/packages/backend/src/main/java/com/tracegrade/dto/response/FieldError.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/response/FieldError.java
@@ -1,5 +1,6 @@
 package com.tracegrade.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,9 +8,15 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
+@Schema(description = "Validation error detail for a single request field")
 public class FieldError {
 
+    @Schema(description = "Name of the field that failed validation", example = "email")
     private final String field;
+
+    @Schema(description = "Validation constraint code", example = "NotBlank")
     private final String code;
+
+    @Schema(description = "Human-readable validation message", example = "must not be blank")
     private final String message;
 }

--- a/packages/backend/src/main/java/com/tracegrade/dto/response/FileUploadResponse.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/response/FileUploadResponse.java
@@ -3,16 +3,27 @@ package com.tracegrade.dto.response;
 import java.time.Instant;
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "Result for a single uploaded exam submission file")
 public class FileUploadResponse {
 
+    @Schema(description = "UUID of the newly created student submission record")
     private UUID submissionId;
+
+    @Schema(description = "Storage URL of the uploaded file")
     private String fileUrl;
+
+    @Schema(description = "Original file name as provided by the client", example = "exam-page1.jpg")
     private String fileName;
+
+    @Schema(description = "Initial submission status after upload", example = "PENDING")
     private String status;
+
+    @Schema(description = "UTC timestamp when the file was uploaded")
     private Instant uploadedAt;
 }

--- a/packages/backend/src/main/java/com/tracegrade/dto/response/GradingEnqueuedResponse.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/response/GradingEnqueuedResponse.java
@@ -3,6 +3,7 @@ package com.tracegrade.dto.response;
 import java.time.Instant;
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,9 +13,10 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Response returned after requesting AI grading for a submission")
 public class GradingEnqueuedResponse {
 
-    /** The submission this grading job is for. */
+    @Schema(description = "UUID of the submission this grading job is for")
     private UUID submissionId;
 
     /**
@@ -25,8 +27,10 @@ public class GradingEnqueuedResponse {
      *   <li>{@code ALREADY_GRADED} – a result already existed; no new job enqueued</li>
      * </ul>
      */
+    @Schema(description = "Grading job status: QUEUED (async), COMPLETED (sync), or ALREADY_GRADED",
+            example = "QUEUED", allowableValues = {"QUEUED", "COMPLETED", "ALREADY_GRADED"})
     private String status;
 
-    /** Timestamp when the enqueue request was processed. */
+    @Schema(description = "UTC timestamp when the enqueue request was processed")
     private Instant enqueuedAt;
 }

--- a/packages/backend/src/main/java/com/tracegrade/dto/response/GradingResultResponse.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/response/GradingResultResponse.java
@@ -4,44 +4,64 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "Full AI grading result for a student submission")
 public class GradingResultResponse {
 
+    @Schema(description = "Unique identifier of the grading result")
     private UUID gradeId;
+
+    @Schema(description = "UUID of the submission that was graded")
     private UUID submissionId;
 
-    /** SubmissionStatus name: COMPLETED or FAILED */
+    @Schema(description = "Grading outcome: COMPLETED or FAILED", example = "COMPLETED",
+            allowableValues = {"COMPLETED", "FAILED"})
     private String status;
 
-    /** Score as a percentage (0–100), null on failure before aggregation */
+    @Schema(description = "AI-assigned score as a percentage (0–100); null when grading failed before aggregation",
+            example = "88.5")
     private BigDecimal aiScore;
 
-    /** Same as aiScore until a teacher override is applied */
+    @Schema(description = "Final score (equals aiScore unless a teacher has overridden it)", example = "90.0")
     private BigDecimal finalScore;
 
-    /** Average confidence across all questions, on 0–100 scale */
+    @Schema(description = "Average AI confidence across all questions, on a 0–100 scale", example = "92.3")
     private BigDecimal confidenceScore;
 
+    @Schema(description = "true when the confidence fell below the threshold and teacher review is required",
+            example = "false")
     private Boolean needsReview;
 
-    /** JSON array of per-question scoring detail */
+    @Schema(description = "JSON array of per-question scoring detail",
+            example = "[{\"question\":1,\"score\":4,\"maxScore\":5}]")
     private String questionScores;
 
-    /** Concatenated per-question AI feedback */
+    @Schema(description = "Concatenated per-question AI feedback text")
     private String aiFeedback;
 
+    @Schema(description = "true if a teacher manually overrode the AI score", example = "false")
     private Boolean teacherOverride;
-    private UUID    reviewedBy;
+
+    @Schema(description = "UUID of the teacher who performed the review")
+    private UUID reviewedBy;
+
+    @Schema(description = "UTC timestamp when the teacher review was submitted")
     private Instant reviewedAt;
 
-    /** First image URL from the student's submission; null if unavailable */
+    @Schema(description = "URL of the first submission image; null if unavailable")
     private String submissionImageUrl;
 
+    @Schema(description = "Time taken to process and grade the submission, in milliseconds", example = "1240")
     private Integer processingTimeMs;
+
+    @Schema(description = "UTC timestamp when the grading result was created")
     private Instant createdAt;
+
+    @Schema(description = "UTC timestamp of the last update")
     private Instant updatedAt;
 }

--- a/packages/backend/src/main/java/com/tracegrade/dto/response/SchoolResponse.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/response/SchoolResponse.java
@@ -1,6 +1,7 @@
 package com.tracegrade.dto.response;
 
 import com.tracegrade.domain.model.SchoolType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,16 +14,36 @@ import java.util.UUID;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "School record returned by the Schools API")
 public class SchoolResponse {
 
+    @Schema(description = "Unique identifier of the school")
     private UUID id;
+
+    @Schema(description = "Full display name of the school", example = "Springfield High School")
     private String name;
+
+    @Schema(description = "School classification type", example = "HIGH")
     private SchoolType schoolType;
+
+    @Schema(description = "Physical address of the school", example = "742 Evergreen Terrace, Springfield")
     private String address;
+
+    @Schema(description = "Contact phone number", example = "+1-555-0100")
     private String phone;
+
+    @Schema(description = "Contact email address", example = "admin@springfield-high.edu")
     private String email;
+
+    @Schema(description = "IANA timezone identifier", example = "America/New_York")
     private String timezone;
+
+    @Schema(description = "Whether the school is currently active", example = "true")
     private Boolean isActive;
+
+    @Schema(description = "UTC timestamp when the school was created")
     private Instant createdAt;
+
+    @Schema(description = "UTC timestamp of the last update")
     private Instant updatedAt;
 }

--- a/packages/backend/src/main/java/com/tracegrade/dto/response/SubmissionStatusResponse.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/response/SubmissionStatusResponse.java
@@ -4,36 +4,58 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "Current status and grading summary for a student submission")
 public class SubmissionStatusResponse {
 
+    @Schema(description = "Unique identifier of the submission")
     private UUID submissionId;
+
+    @Schema(description = "UUID of the assignment this submission belongs to")
     private UUID assignmentId;
+
+    @Schema(description = "UUID of the student who made the submission")
     private UUID studentId;
 
-    /** SubmissionStatus name: PENDING, PROCESSING, COMPLETED, or FAILED */
+    @Schema(description = "Current processing status", example = "COMPLETED",
+            allowableValues = {"PENDING", "PROCESSING", "COMPLETED", "FAILED"})
     private String status;
 
+    @Schema(description = "UTC timestamp when the submission was uploaded")
     private Instant submittedAt;
 
-    /** Reflects when the status last changed (populated by @PreUpdate on BaseEntity) */
+    @Schema(description = "UTC timestamp when the status last changed")
     private Instant updatedAt;
 
-    /** Non-null only when a GradingResult record has been linked to this submission */
+    @Schema(description = "Grading summary; present only once a GradingResult has been linked")
     private GradingResultSummary gradingResult;
 
     @Getter
     @Builder
+    @Schema(description = "Condensed grading result summary embedded in the submission status")
     public static class GradingResultSummary {
+
+        @Schema(description = "UUID of the grading result")
         private UUID gradeId;
+
+        @Schema(description = "AI-assigned score as a percentage (0–100)", example = "88.5")
         private BigDecimal aiScore;
+
+        @Schema(description = "Final score after any teacher override", example = "90.0")
         private BigDecimal finalScore;
+
+        @Schema(description = "Average AI confidence (0–100)", example = "92.3")
         private BigDecimal confidenceScore;
+
+        @Schema(description = "true when teacher review is required", example = "false")
         private Boolean needsReview;
+
+        @Schema(description = "true if a teacher overrode the AI score", example = "false")
         private Boolean teacherOverride;
     }
 }

--- a/packages/backend/src/main/java/com/tracegrade/grading/GradingController.java
+++ b/packages/backend/src/main/java/com/tracegrade/grading/GradingController.java
@@ -3,6 +3,12 @@ package com.tracegrade.grading;
 import java.util.List;
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,34 +29,75 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Grading", description = "AI grading lifecycle: enqueue jobs, retrieve results, and manage teacher reviews")
+@SecurityRequirement(name = "BearerAuth")
 public class GradingController {
 
     private final GradingService gradingService;
 
+    @Operation(
+            summary = "Enqueue a submission for AI grading",
+            description = "Publishes a grading job for the given submission. If SQS is configured the job is "
+                    + "processed asynchronously; otherwise it is graded synchronously before this call returns."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "202", description = "Grading job accepted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Submission not found", content = @Content)
+    })
     @PostMapping("/api/submissions/{submissionId}/grade")
     public ResponseEntity<ApiResponse<GradingEnqueuedResponse>> enqueueGrading(
+            @Parameter(description = "UUID of the submission to grade", required = true)
             @PathVariable UUID submissionId) {
 
         GradingEnqueuedResponse response = gradingService.enqueueGrading(submissionId);
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(ApiResponse.success(response));
     }
 
+    @Operation(
+            summary = "Get grading result for a submission",
+            description = "Returns the current grading result for the given submission, including AI score, "
+                    + "confidence, and whether the result requires teacher review."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Grading result returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Submission or result not found", content = @Content)
+    })
     @GetMapping("/api/submissions/{submissionId}/grade")
     public ResponseEntity<ApiResponse<GradingResultResponse>> getResult(
+            @Parameter(description = "UUID of the submission", required = true)
             @PathVariable UUID submissionId) {
 
         GradingResultResponse response = gradingService.getResult(submissionId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @Operation(
+            summary = "List grading results pending teacher review",
+            description = "Returns all grading results where the AI confidence fell below the configured threshold "
+                    + "and a teacher review is required."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "List of pending reviews returned")
+    })
     @GetMapping("/api/grading/reviews/pending")
     public ResponseEntity<ApiResponse<List<GradingResultResponse>>> getPendingReviews() {
         List<GradingResultResponse> response = gradingService.getPendingReviews();
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @Operation(
+            summary = "Submit a teacher review for a grading result",
+            description = "Allows a teacher to confirm or override the AI-assigned score and optionally update "
+                    + "per-question scores."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Review applied, updated result returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid review payload", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Grading result not found", content = @Content)
+    })
     @PatchMapping("/api/grading/{gradeId}/review")
     public ResponseEntity<ApiResponse<GradingResultResponse>> reviewGrade(
+            @Parameter(description = "UUID of the grading result to review", required = true)
             @PathVariable UUID gradeId,
             @RequestBody @Valid GradingReviewRequest request) {
 

--- a/packages/backend/src/main/java/com/tracegrade/rubric/AnswerRubricController.java
+++ b/packages/backend/src/main/java/com/tracegrade/rubric/AnswerRubricController.java
@@ -3,6 +3,12 @@ package com.tracegrade.rubric;
 import java.util.List;
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -27,12 +33,25 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/exam-templates/{examTemplateId}/rubrics")
 @RequiredArgsConstructor
 @Validated
+@Tag(name = "Answer Rubrics", description = "Manage answer rubrics for exam templates. Each rubric defines the expected answer and scoring for one question.")
+@SecurityRequirement(name = "BearerAuth")
 public class AnswerRubricController {
 
     private final AnswerRubricService rubricService;
 
+    @Operation(
+            summary = "Create a rubric for a question",
+            description = "Adds a new answer rubric entry to the specified exam template. "
+                    + "The question number must be unique within the template."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Rubric created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid request or duplicate question number", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Exam template not found", content = @Content)
+    })
     @PostMapping
     public ResponseEntity<ApiResponse<AnswerRubricResponse>> create(
+            @Parameter(description = "UUID of the exam template", required = true)
             @PathVariable UUID examTemplateId,
             @Valid @RequestBody CreateAnswerRubricRequest request) {
 
@@ -40,26 +59,56 @@ public class AnswerRubricController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 
+    @Operation(
+            summary = "List all rubrics for an exam template",
+            description = "Returns every answer rubric belonging to the given exam template, ordered by question number."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Rubric list returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Exam template not found", content = @Content)
+    })
     @GetMapping
     public ResponseEntity<ApiResponse<List<AnswerRubricResponse>>> listAll(
+            @Parameter(description = "UUID of the exam template", required = true)
             @PathVariable UUID examTemplateId) {
 
         List<AnswerRubricResponse> response = rubricService.listByExamTemplate(examTemplateId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @Operation(
+            summary = "Get a single rubric by ID",
+            description = "Returns the rubric for a specific question within an exam template."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Rubric returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Exam template or rubric not found", content = @Content)
+    })
     @GetMapping("/{rubricId}")
     public ResponseEntity<ApiResponse<AnswerRubricResponse>> getById(
+            @Parameter(description = "UUID of the exam template", required = true)
             @PathVariable UUID examTemplateId,
+            @Parameter(description = "UUID of the rubric", required = true)
             @PathVariable UUID rubricId) {
 
         AnswerRubricResponse response = rubricService.getById(examTemplateId, rubricId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @Operation(
+            summary = "Update a rubric",
+            description = "Replaces the rubric's fields with the values in the request body."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Rubric updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid request", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Exam template or rubric not found", content = @Content)
+    })
     @PutMapping("/{rubricId}")
     public ResponseEntity<ApiResponse<AnswerRubricResponse>> update(
+            @Parameter(description = "UUID of the exam template", required = true)
             @PathVariable UUID examTemplateId,
+            @Parameter(description = "UUID of the rubric", required = true)
             @PathVariable UUID rubricId,
             @Valid @RequestBody UpdateAnswerRubricRequest request) {
 
@@ -67,9 +116,19 @@ public class AnswerRubricController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @Operation(
+            summary = "Delete a rubric",
+            description = "Permanently removes the rubric from the exam template."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "Rubric deleted"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Exam template or rubric not found", content = @Content)
+    })
     @DeleteMapping("/{rubricId}")
     public ResponseEntity<Void> delete(
+            @Parameter(description = "UUID of the exam template", required = true)
             @PathVariable UUID examTemplateId,
+            @Parameter(description = "UUID of the rubric", required = true)
             @PathVariable UUID rubricId) {
 
         rubricService.delete(examTemplateId, rubricId);

--- a/packages/backend/src/main/java/com/tracegrade/submission/StudentSubmissionController.java
+++ b/packages/backend/src/main/java/com/tracegrade/submission/StudentSubmissionController.java
@@ -3,6 +3,12 @@ package com.tracegrade.submission;
 import java.util.List;
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -33,77 +39,88 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/submissions")
 @RequiredArgsConstructor
 @Validated
+@Tag(name = "Student Submissions", description = "Upload exam images and track submission processing status")
+@SecurityRequirement(name = "BearerAuth")
 public class StudentSubmissionController {
 
     private final SubmissionUploadService uploadService;
     private final StudentSubmissionService submissionService;
 
-    /**
-     * Upload a single exam submission image.
-     *
-     * POST /api/submissions/upload
-     * Content-Type: multipart/form-data
-     *
-     * @param assignmentId the assignment this submission belongs to
-     * @param studentId    the student making the submission
-     * @param file         the exam image file (JPEG, PNG, PDF, or HEIC; max 10 MB)
-     */
+    @Operation(
+            summary = "Upload a single exam submission image",
+            description = "Accepts a multipart file (JPEG, PNG, PDF, or HEIC; max 10 MB) and stores it for "
+                    + "the specified assignment and student."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "File uploaded successfully"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid file type, size exceeded, or missing parameters", content = @Content)
+    })
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<FileUploadResponse>> uploadFile(
+            @Parameter(description = "UUID of the assignment this submission belongs to", required = true)
             @RequestParam @NotNull UUID assignmentId,
+            @Parameter(description = "UUID of the student making the submission", required = true)
             @RequestParam @NotNull UUID studentId,
+            @Parameter(description = "Exam image file (JPEG, PNG, PDF, or HEIC; max 10 MB)", required = true)
             @RequestPart("file") @ValidFileUpload MultipartFile file) {
 
         FileUploadResponse response = uploadService.uploadSingle(assignmentId, studentId, file);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    /**
-     * Upload multiple exam submission images in a single request.
-     *
-     * POST /api/submissions/upload/batch
-     * Content-Type: multipart/form-data
-     *
-     * @param assignmentId the assignment these submissions belong to
-     * @param studentId    the student making the submissions
-     * @param files        the exam image files (each: JPEG, PNG, PDF, or HEIC; max 10 MB)
-     */
+    @Operation(
+            summary = "Upload multiple exam submission images",
+            description = "Accepts multiple multipart files in a single request. Each file must be JPEG, PNG, PDF, "
+                    + "or HEIC and no larger than 10 MB."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Files uploaded, per-file results returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "One or more files failed validation", content = @Content)
+    })
     @PostMapping(value = "/upload/batch", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<BatchUploadResponse>> uploadFiles(
+            @Parameter(description = "UUID of the assignment these submissions belong to", required = true)
             @RequestParam @NotNull UUID assignmentId,
+            @Parameter(description = "UUID of the student making the submissions", required = true)
             @RequestParam @NotNull UUID studentId,
+            @Parameter(description = "Exam image files (each: JPEG, PNG, PDF, or HEIC; max 10 MB)", required = true)
             @RequestPart("files") @NotEmpty List<@ValidFileUpload MultipartFile> files) {
 
         BatchUploadResponse response = uploadService.uploadBatch(assignmentId, studentId, files);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    /**
-     * Retrieve the current status and grading info for a submission.
-     *
-     * GET /api/submissions/{submissionId}
-     *
-     * @param submissionId the submission to look up
-     */
+    @Operation(
+            summary = "Get submission status and grading info",
+            description = "Returns the current processing status of a submission and, once graded, a summary "
+                    + "of the grading result."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Submission status returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Submission not found", content = @Content)
+    })
     @GetMapping("/{submissionId}")
     public ResponseEntity<ApiResponse<SubmissionStatusResponse>> getSubmission(
+            @Parameter(description = "UUID of the submission", required = true)
             @PathVariable UUID submissionId) {
 
         SubmissionStatusResponse response = submissionService.getSubmission(submissionId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    /**
-     * Update the processing status of a submission.
-     *
-     * PATCH /api/submissions/{submissionId}/status
-     * Content-Type: application/json
-     *
-     * @param submissionId the submission to update
-     * @param request      body containing the new status
-     */
+    @Operation(
+            summary = "Update submission processing status",
+            description = "Transitions the submission to a new status (PENDING, PROCESSING, COMPLETED, or FAILED). "
+                    + "Typically used by internal workers rather than end users."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Status updated, updated submission returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid status value", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Submission not found", content = @Content)
+    })
     @PatchMapping("/{submissionId}/status")
     public ResponseEntity<ApiResponse<SubmissionStatusResponse>> updateStatus(
+            @Parameter(description = "UUID of the submission to update", required = true)
             @PathVariable UUID submissionId,
             @Valid @RequestBody UpdateSubmissionStatusRequest request) {
 

--- a/packages/backend/src/main/resources/application.yml
+++ b/packages/backend/src/main/resources/application.yml
@@ -143,6 +143,16 @@ sqs:
   wait-time-seconds: ${SQS_WAIT_TIME_SECONDS:20}
   max-messages-per-poll: ${SQS_MAX_MESSAGES_PER_POLL:10}
 
+# SpringDoc / Swagger UI Configuration
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    operations-sorter: method
+    tags-sorter: alpha
+  show-actuator: false
+
 # Logging Configuration
 logging:
   level:


### PR DESCRIPTION
## Summary

- Integrates **SpringDoc-OpenAPI** (`springdoc-openapi-starter-webmvc-ui:2.3.0`) to auto-generate interactive Swagger UI and a machine-readable OpenAPI 3.1 specification
- Adds a new `OpenApiConfig` class with global API metadata (title, version, server) and a **JWT Bearer security scheme**
- Annotates all 4 REST controllers (18 endpoints total) with `@Tag`, `@Operation`, `@ApiResponses`, `@Parameter`, and `@SecurityRequirement`
- Annotates all 6 request DTOs and 10 response DTOs with `@Schema` field descriptions and examples
- Hides `CsrfTokenController` from the public docs with `@Hidden`
- Permits Swagger UI / api-docs paths in `SecurityConfig` and adds them to the CSRF ignore list

## Endpoints Documented

| Tag | Endpoints |
|-----|-----------|
| **Grading** | `POST /api/submissions/{id}/grade`, `GET /api/submissions/{id}/grade`, `GET /api/grading/reviews/pending`, `PATCH /api/grading/{id}/review` |
| **Answer Rubrics** | `POST/GET /api/exam-templates/{id}/rubrics`, `GET/PUT/DELETE /api/exam-templates/{id}/rubrics/{id}` |
| **Student Submissions** | `POST /api/submissions/upload`, `POST /api/submissions/upload/batch`, `GET /api/submissions/{id}`, `PATCH /api/submissions/{id}/status` |
| **Schools** | `GET/POST /api/schools`, `GET/PATCH/DELETE /api/schools/{id}` |

## Test Plan

- [ ] Reload Maven project (pom.xml changed) then start the app: `mvn spring-boot:run`
- [ ] Open `http://localhost:8080/swagger-ui.html` — Swagger UI loads with all 4 tags
- [ ] Open `http://localhost:8080/v3/api-docs` — returns valid OpenAPI 3.1 JSON
- [ ] Expand an endpoint, click "Try it out", execute a request — response renders correctly
- [ ] Confirm `/api/csrf/token` does NOT appear in Swagger UI

Closes #9