### PR TITLE
[FEAT-022] Implement Student Entity, Repository & API

### DIFF
--- a/packages/backend/src/main/java/com/tracegrade/domain/model/Student.java
+++ b/packages/backend/src/main/java/com/tracegrade/domain/model/Student.java
@@ -1,0 +1,57 @@
+package com.tracegrade.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "students")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Student extends BaseEntity {
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "school_id", nullable = false, updatable = false)
+    private School school;
+
+    @NotBlank
+    @Size(max = 100)
+    @Column(name = "first_name", nullable = false, length = 100)
+    private String firstName;
+
+    @NotBlank
+    @Size(max = 100)
+    @Column(name = "last_name", nullable = false, length = 100)
+    private String lastName;
+
+    @NotBlank
+    @Email
+    @Size(max = 200)
+    @Column(name = "email", nullable = false, length = 200)
+    private String email;
+
+    @Size(max = 50)
+    @Column(name = "student_number", length = 50)
+    private String studentNumber;
+
+    @NotNull
+    @Column(name = "is_active", nullable = false)
+    @Builder.Default
+    private Boolean isActive = true;
+}

--- a/packages/backend/src/main/java/com/tracegrade/domain/repository/StudentRepository.java
+++ b/packages/backend/src/main/java/com/tracegrade/domain/repository/StudentRepository.java
@@ -1,0 +1,23 @@
+package com.tracegrade.domain.repository;
+
+import com.tracegrade.domain.model.Student;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface StudentRepository extends JpaRepository<Student, UUID> {
+
+    List<Student> findBySchoolIdAndIsActiveTrue(UUID schoolId);
+
+    List<Student> findBySchoolId(UUID schoolId);
+
+    Optional<Student> findByIdAndSchoolId(UUID id, UUID schoolId);
+
+    boolean existsByEmailAndSchoolId(String email, UUID schoolId);
+
+    boolean existsByStudentNumberAndSchoolId(String studentNumber, UUID schoolId);
+}

--- a/packages/backend/src/main/java/com/tracegrade/dto/request/CreateStudentRequest.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/request/CreateStudentRequest.java
@@ -1,0 +1,47 @@
+package com.tracegrade.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "Request body for enrolling a new student")
+public class CreateStudentRequest {
+
+    @NotNull
+    @Schema(description = "UUID of the school this student belongs to", requiredMode = Schema.RequiredMode.REQUIRED, example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
+    private UUID schoolId;
+
+    @NotBlank
+    @Size(max = 100)
+    @Schema(description = "Student's first name", example = "Jane", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String firstName;
+
+    @NotBlank
+    @Size(max = 100)
+    @Schema(description = "Student's last name", example = "Doe", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String lastName;
+
+    @NotBlank
+    @Email
+    @Size(max = 200)
+    @Schema(description = "Student's email address (unique per school)", example = "jane.doe@school.edu", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String email;
+
+    @Size(max = 50)
+    @Schema(description = "Optional external student ID / roll number", example = "STU-2026-001")
+    private String studentNumber;
+}

--- a/packages/backend/src/main/java/com/tracegrade/dto/request/UpdateStudentRequest.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/request/UpdateStudentRequest.java
@@ -1,0 +1,39 @@
+package com.tracegrade.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "Request body for partially updating a student. Only provided fields are changed.")
+public class UpdateStudentRequest {
+
+    @Size(max = 100)
+    @Schema(description = "Updated first name", example = "Janet")
+    private String firstName;
+
+    @Size(max = 100)
+    @Schema(description = "Updated last name", example = "Smith")
+    private String lastName;
+
+    @Email
+    @Size(max = 200)
+    @Schema(description = "Updated email address (must be unique within the school)", example = "janet.smith@school.edu")
+    private String email;
+
+    @Size(max = 50)
+    @Schema(description = "Updated external student ID / roll number", example = "STU-2026-002")
+    private String studentNumber;
+
+    @Schema(description = "Set to false to deactivate the student", example = "true")
+    private Boolean isActive;
+}

--- a/packages/backend/src/main/java/com/tracegrade/dto/response/StudentResponse.java
+++ b/packages/backend/src/main/java/com/tracegrade/dto/response/StudentResponse.java
@@ -1,0 +1,45 @@
+package com.tracegrade.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Student record returned by the Students API")
+public class StudentResponse {
+
+    @Schema(description = "Unique identifier of the student")
+    private UUID id;
+
+    @Schema(description = "UUID of the school this student belongs to")
+    private UUID schoolId;
+
+    @Schema(description = "Student's first name", example = "Jane")
+    private String firstName;
+
+    @Schema(description = "Student's last name", example = "Doe")
+    private String lastName;
+
+    @Schema(description = "Student's email address", example = "jane.doe@school.edu")
+    private String email;
+
+    @Schema(description = "Optional external student ID / roll number", example = "STU-2026-001")
+    private String studentNumber;
+
+    @Schema(description = "Whether the student is currently active", example = "true")
+    private Boolean isActive;
+
+    @Schema(description = "UTC timestamp when the student record was created")
+    private Instant createdAt;
+
+    @Schema(description = "UTC timestamp of the last update")
+    private Instant updatedAt;
+}

--- a/packages/backend/src/main/java/com/tracegrade/exception/DuplicateResourceException.java
+++ b/packages/backend/src/main/java/com/tracegrade/exception/DuplicateResourceException.java
@@ -1,0 +1,19 @@
+package com.tracegrade.exception;
+
+public class DuplicateResourceException extends RuntimeException {
+
+    private final String resourceType;
+    private final String field;
+    private final String value;
+
+    public DuplicateResourceException(String resourceType, String field, String value) {
+        super(resourceType + " with " + field + " '" + value + "' already exists");
+        this.resourceType = resourceType;
+        this.field = field;
+        this.value = value;
+    }
+
+    public String getResourceType() { return resourceType; }
+    public String getField()        { return field; }
+    public String getValue()        { return value; }
+}

--- a/packages/backend/src/main/java/com/tracegrade/exception/GlobalExceptionHandler.java
+++ b/packages/backend/src/main/java/com/tracegrade/exception/GlobalExceptionHandler.java
@@ -170,6 +170,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error(error));
     }
 
+    @ExceptionHandler(DuplicateResourceException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDuplicateResource(
+            DuplicateResourceException ex) {
+        ApiError error = ApiError.of("CONFLICT", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ApiResponse.error(error));
+    }
+
     @ExceptionHandler(InputSanitizationException.class)
     public ResponseEntity<ApiResponse<Void>> handleSanitizationRejection(
             InputSanitizationException ex) {

--- a/packages/backend/src/main/java/com/tracegrade/student/StudentController.java
+++ b/packages/backend/src/main/java/com/tracegrade/student/StudentController.java
@@ -1,0 +1,140 @@
+package com.tracegrade.student;
+
+import com.tracegrade.dto.request.CreateStudentRequest;
+import com.tracegrade.dto.request.UpdateStudentRequest;
+import com.tracegrade.dto.response.ApiResponse;
+import com.tracegrade.dto.response.StudentResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/schools/{schoolId}/students")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "Students", description = "Student management scoped to a school. All operations require a valid schoolId path parameter.")
+@SecurityRequirement(name = "BearerAuth")
+public class StudentController {
+
+    private final StudentService studentService;
+
+    @Operation(
+            summary = "List students for a school",
+            description = "Returns all students belonging to the specified school. Pass `includeInactive=true` to include deactivated records."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Student list returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "School not found", content = @Content)
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<StudentResponse>>> getStudents(
+            @Parameter(description = "UUID of the school", required = true)
+            @PathVariable UUID schoolId,
+            @Parameter(description = "When true, include deactivated students", required = false)
+            @RequestParam(defaultValue = "false") boolean includeInactive) {
+
+        List<StudentResponse> students = includeInactive
+                ? studentService.getAllStudentsBySchool(schoolId)
+                : studentService.getActiveStudentsBySchool(schoolId);
+
+        return ResponseEntity.ok(ApiResponse.success(students));
+    }
+
+    @Operation(
+            summary = "Get a student by ID",
+            description = "Returns a single student record scoped to the given school."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Student returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "School or student not found", content = @Content)
+    })
+    @GetMapping("/{studentId}")
+    public ResponseEntity<ApiResponse<StudentResponse>> getStudent(
+            @Parameter(description = "UUID of the school", required = true)
+            @PathVariable UUID schoolId,
+            @Parameter(description = "UUID of the student", required = true)
+            @PathVariable UUID studentId) {
+        return ResponseEntity.ok(ApiResponse.success(studentService.getStudent(schoolId, studentId)));
+    }
+
+    @Operation(
+            summary = "Enroll a new student",
+            description = "Creates a new student record within the specified school. Email must be unique per school."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Student created"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation error", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "School not found", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Email or student number already in use", content = @Content)
+    })
+    @PostMapping
+    public ResponseEntity<ApiResponse<StudentResponse>> createStudent(
+            @Parameter(description = "UUID of the school", required = true)
+            @PathVariable UUID schoolId,
+            @Valid @RequestBody CreateStudentRequest request) {
+
+        // Ensure path variable and body are consistent
+        request.setSchoolId(schoolId);
+
+        StudentResponse created = studentService.createStudent(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(created));
+    }
+
+    @Operation(
+            summary = "Update a student",
+            description = "Partially updates a student record. Only provided fields are changed."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Student updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Validation error", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "School or student not found", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Email or student number already in use", content = @Content)
+    })
+    @PatchMapping("/{studentId}")
+    public ResponseEntity<ApiResponse<StudentResponse>> updateStudent(
+            @Parameter(description = "UUID of the school", required = true)
+            @PathVariable UUID schoolId,
+            @Parameter(description = "UUID of the student", required = true)
+            @PathVariable UUID studentId,
+            @Valid @RequestBody UpdateStudentRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(studentService.updateStudent(schoolId, studentId, request)));
+    }
+
+    @Operation(
+            summary = "Deactivate a student",
+            description = "Soft-deletes a student by setting isActive=false. The record is retained for historical grading data."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "Student deactivated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "School or student not found", content = @Content)
+    })
+    @DeleteMapping("/{studentId}")
+    public ResponseEntity<Void> deactivateStudent(
+            @Parameter(description = "UUID of the school", required = true)
+            @PathVariable UUID schoolId,
+            @Parameter(description = "UUID of the student", required = true)
+            @PathVariable UUID studentId) {
+        studentService.deactivateStudent(schoolId, studentId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/packages/backend/src/main/java/com/tracegrade/student/StudentService.java
+++ b/packages/backend/src/main/java/com/tracegrade/student/StudentService.java
@@ -1,0 +1,138 @@
+package com.tracegrade.student;
+
+import com.tracegrade.domain.model.School;
+import com.tracegrade.domain.model.Student;
+import com.tracegrade.domain.repository.SchoolRepository;
+import com.tracegrade.domain.repository.StudentRepository;
+import com.tracegrade.dto.request.CreateStudentRequest;
+import com.tracegrade.dto.request.UpdateStudentRequest;
+import com.tracegrade.dto.response.StudentResponse;
+import com.tracegrade.exception.DuplicateResourceException;
+import com.tracegrade.exception.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@SuppressWarnings("null")
+public class StudentService {
+
+    private final StudentRepository studentRepository;
+    private final SchoolRepository schoolRepository;
+
+    @Transactional(readOnly = true)
+    public List<StudentResponse> getActiveStudentsBySchool(UUID schoolId) {
+        requireSchoolExists(schoolId);
+        return studentRepository.findBySchoolIdAndIsActiveTrue(schoolId).stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<StudentResponse> getAllStudentsBySchool(UUID schoolId) {
+        requireSchoolExists(schoolId);
+        return studentRepository.findBySchoolId(schoolId).stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public StudentResponse getStudent(UUID schoolId, UUID studentId) {
+        return toResponse(findByIdAndSchool(schoolId, studentId));
+    }
+
+    @Transactional
+    public StudentResponse createStudent(CreateStudentRequest request) {
+        School school = schoolRepository.findById(request.getSchoolId())
+                .orElseThrow(() -> new ResourceNotFoundException("School", request.getSchoolId()));
+
+        if (studentRepository.existsByEmailAndSchoolId(request.getEmail(), request.getSchoolId())) {
+            throw new DuplicateResourceException("Student", "email", request.getEmail());
+        }
+
+        if (request.getStudentNumber() != null &&
+                studentRepository.existsByStudentNumberAndSchoolId(request.getStudentNumber(), request.getSchoolId())) {
+            throw new DuplicateResourceException("Student", "studentNumber", request.getStudentNumber());
+        }
+
+        Student student = Student.builder()
+                .school(school)
+                .firstName(request.getFirstName())
+                .lastName(request.getLastName())
+                .email(request.getEmail().toLowerCase())
+                .studentNumber(request.getStudentNumber())
+                .build();
+
+        log.info("Creating student: email={}, schoolId={}", request.getEmail(), request.getSchoolId());
+        return toResponse(studentRepository.save(student));
+    }
+
+    @Transactional
+    public StudentResponse updateStudent(UUID schoolId, UUID studentId, UpdateStudentRequest request) {
+        Student student = findByIdAndSchool(schoolId, studentId);
+
+        if (request.getEmail() != null && !request.getEmail().equalsIgnoreCase(student.getEmail())) {
+            if (studentRepository.existsByEmailAndSchoolId(request.getEmail(), schoolId)) {
+                throw new DuplicateResourceException("Student", "email", request.getEmail());
+            }
+            student.setEmail(request.getEmail().toLowerCase());
+        }
+
+        if (request.getStudentNumber() != null && !request.getStudentNumber().equals(student.getStudentNumber())) {
+            if (studentRepository.existsByStudentNumberAndSchoolId(request.getStudentNumber(), schoolId)) {
+                throw new DuplicateResourceException("Student", "studentNumber", request.getStudentNumber());
+            }
+            student.setStudentNumber(request.getStudentNumber());
+        }
+
+        if (request.getFirstName() != null) student.setFirstName(request.getFirstName());
+        if (request.getLastName() != null)  student.setLastName(request.getLastName());
+        if (request.getIsActive() != null)  student.setIsActive(request.getIsActive());
+
+        log.info("Updating student {}", studentId);
+        return toResponse(studentRepository.save(student));
+    }
+
+    @Transactional
+    public void deactivateStudent(UUID schoolId, UUID studentId) {
+        Student student = findByIdAndSchool(schoolId, studentId);
+        log.info("Deactivating student {}", studentId);
+        student.setIsActive(false);
+        studentRepository.save(student);
+    }
+
+    // ---- helpers ----
+
+    private Student findByIdAndSchool(UUID schoolId, UUID studentId) {
+        requireSchoolExists(schoolId);
+        return studentRepository.findByIdAndSchoolId(studentId, schoolId)
+                .orElseThrow(() -> new ResourceNotFoundException("Student", studentId));
+    }
+
+    private void requireSchoolExists(UUID schoolId) {
+        if (!schoolRepository.existsById(schoolId)) {
+            throw new ResourceNotFoundException("School", schoolId);
+        }
+    }
+
+    private StudentResponse toResponse(Student s) {
+        return StudentResponse.builder()
+                .id(s.getId())
+                .schoolId(s.getSchool().getId())
+                .firstName(s.getFirstName())
+                .lastName(s.getLastName())
+                .email(s.getEmail())
+                .studentNumber(s.getStudentNumber())
+                .isActive(s.getIsActive())
+                .createdAt(s.getCreatedAt())
+                .updatedAt(s.getUpdatedAt())
+                .build();
+    }
+}

--- a/packages/backend/src/main/resources/db/migration/V4__add_student_entity.sql
+++ b/packages/backend/src/main/resources/db/migration/V4__add_student_entity.sql
@@ -1,0 +1,25 @@
+-- FEAT-022: Add Student entity for Gradebook MVP
+
+CREATE TABLE students (
+    id            UUID         PRIMARY KEY,
+    school_id     UUID         NOT NULL REFERENCES schools(id),
+    first_name    VARCHAR(100) NOT NULL,
+    last_name     VARCHAR(100) NOT NULL,
+    email         VARCHAR(200) NOT NULL,
+    student_number VARCHAR(50),
+    is_active     BOOLEAN      NOT NULL DEFAULT TRUE,
+    created_at    TIMESTAMP    NOT NULL,
+    updated_at    TIMESTAMP    NOT NULL
+);
+
+-- Enforce unique email per school
+CREATE UNIQUE INDEX uq_students_school_email
+    ON students(school_id, email);
+
+-- Enforce unique student number per school (when present)
+CREATE UNIQUE INDEX uq_students_school_number
+    ON students(school_id, student_number)
+    WHERE student_number IS NOT NULL;
+
+CREATE INDEX idx_students_school_active
+    ON students(school_id, is_active);


### PR DESCRIPTION
## Summary

Implements the Student domain slice for the Gradebook MVP, following the established `SchoolService` / `SchoolController` patterns.

Closes #39

---

## Changes

### Database
- **V4 Flyway migration** — `students` table with:
  - FK `school_id → schools(id)`
  - `UNIQUE (school_id, email)`
  - Partial unique index `(school_id, student_number) WHERE student_number IS NOT NULL`
  - Index on `(school_id, is_active)`

### Backend — Domain
- `Student.java` — JPA entity extending `BaseEntity`, `@ManyToOne(LAZY)` → `School`
- `StudentRepository.java` — school-scoped finders + existence checks

### Backend — DTOs
- `CreateStudentRequest` — `@NotBlank`, `@Email`, `@Size` + Swagger annotations
- `UpdateStudentRequest` — all fields optional (partial update)
- `StudentResponse` — full response shape with Swagger annotations

### Backend — Service & Controller
- `StudentService` — school-scoped CRUD, email normalisation to lowercase, duplicate-email/student-number guards
- `StudentController` — REST API at `/api/schools/{schoolId}/students`:
  | Method | Path | Description |
  |--------|------|-------------|
  | GET | `/` | List active students (`?includeInactive=true` for all) |
  | GET | `/{studentId}` | Get a single student |
  | POST | `/` | Enroll a new student |
  | PATCH | `/{studentId}` | Partially update a student |
  | DELETE | `/{studentId}` | Soft-deactivate a student |

### Backend — Exceptions
- `DuplicateResourceException` — reusable 409 CONFLICT exception (re-usable across future domain slices)
- `GlobalExceptionHandler` — registered handler → HTTP 409

---

## Testing
- `mvn clean compile` — BUILD SUCCESS (113 source files)

---

## Acceptance Criteria
- [x] Student can be created scoped to a school
- [x] Email is unique per school (409 on conflict)
- [x] Student number is unique per school when provided (409 on conflict)
- [x] Deactivation is a soft-delete (isActive=false)
- [x] All endpoints have Swagger/OpenAPI annotations
- [x] All new entities extend BaseEntity
- [x] Follows SchoolService/SchoolController pattern