### PR TITLE
[FEAT-028] Build Exams UI page

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,19 @@ TraceGrade/
 - **Response Fields**: `totalStudents`, `classCount` (currently `0`), `gradedThisWeek`, `pendingReviews`, `classAverage` (one decimal), `letterGrade` (`A|B|C|D|F`)
 - **Scope Boundary**: FEAT-025 covers backend API delivery only; FEAT-026 frontend dashboard wiring to consume this endpoint is explicitly out of scope.
 
+### FEAT-028 Exams Page UI (Frontend)
+- **Route**: `/exams` — dedicated Exams page for viewing and managing exam templates in a structured list/card UI
+- **Entry Points**: 
+  - Navigate from top navigation menu (Exams link in TopNav)
+  - Direct URL access via browser refresh to `/exams`
+- **Supported UI States**:
+  - **Loading State**: Displayed while exam template data is being fetched from the backend
+  - **Error State**: Displayed when the API call fails (network error, timeout, or server error); includes retry control
+  - **Empty State**: Displayed when no exam templates exist; provides clear CTA for creating the first exam
+  - **Populated State**: Displays exam template list with structured cards, each showing title, question count (if available), and total points (if available)
+- **Per-Item Actions**: Each exam card includes a primary action (open/manage/view) for proceeding into exam workflow
+- **Non-Regression**: Existing `PaperExamsPage` (`/paper-exams`) route and behavior remain completely intact; FEAT-028 is isolated to the new `/exams` route and does not affect paper exam grading workflows
+
 ### Planned Features (Post-MVP)
 - **AI Exam Generation**: Generate custom exams using AI based on topic, difficulty, and learning objectives
 - **Handwritten Answer Grading**: Upload photos of student work and get automatic grading via GPT-4 Vision
@@ -208,6 +221,27 @@ For detailed Docker documentation, see [DOCKER.md](DOCKER.md).
 - **Frontend**: Jest/Vitest for unit tests, Playwright/Cypress for E2E
 - **Backend**: JUnit 5 for unit tests, TestContainers for integration tests
 - **Target Coverage**: 80%+ code coverage
+
+### FEAT-028 Exams Page Verification Checklist
+
+The Exams page (FEAT-028) includes automated and manual verification checks aligned to acceptance criteria (AC-001 through AC-006):
+
+| Criteria | Verification | Status |
+|----------|--------------|--------|
+| **AC-001: Route & Navigation** | Navigate to `/exams` from TopNav; confirm Exams page renders. Direct URL access to `/exams` via browser refresh also works. | `npm run build` validates route wiring |
+| **AC-002: List & Metadata** | With exam template data available, confirm each item shows title, question count (if available), and total points (if available) | Manual: load populated Exams page; verify metadata rendering |
+| **AC-003: State Branches** | Confirm loading, error, and empty states render correctly when API is pending, fails, or returns zero results | Manual: simulate pending/error/empty responses; verify each state appears |
+| **AC-004: Per-Item Actions** | Each exam card includes a primary open/manage action; action is clickable and keyboard-focusable | Manual: navigate exam cards with keyboard; click action control |
+| **AC-005: Paper Exams Non-Regression** | Navigate to `/paper-exams` after FEAT-028 changes; verify existing page still renders and all interactions remain available | Manual: access `/paper-exams` route; test existing paper exam workflow |
+| **AC-006: Missing Field Handling** | Provide exam data missing optional fields (e.g., no question count); confirm page remains stable without runtime errors | Manual: verify long titles do not break layout; missing metadata is handled safely |
+
+**Run checks locally**:
+```bash
+cd packages/frontend
+npm run lint           # Frontend linting
+npm run type-check    # TypeScript validation
+npm run build         # Build validation (includes route wiring)
+```
 
 ## Deployment
 

--- a/packages/frontend/.eslintrc.cjs
+++ b/packages/frontend/.eslintrc.cjs
@@ -1,0 +1,1 @@
+module.exports = { root: true, env: { browser: true, es2020: true }, extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:react-hooks/recommended"], ignorePatterns: ["dist", ".eslintrc.cjs"], parser: "@typescript-eslint/parser", plugins: ["react-refresh"], rules: { "react-refresh/only-export-components": ["warn", { allowConstantExport: true }] } }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,7 +8,9 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -21,6 +23,8 @@
     "@tanstack/react-query": "^5.14.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
@@ -30,9 +34,11 @@
     "eslint": "^8.55.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
+    "jsdom": "^26.0.0",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.3.6",
     "typescript": "^5.3.3",
-    "vite": "^5.0.8"
+    "vite": "^5.0.8",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import TopNav from './components/layout/TopNav'
 import PaperExamsPage from './pages/PaperExamsPage'
 import ManualReviewQueuePage from './pages/ManualReviewQueuePage'
 import DashboardPage from './pages/DashboardPage'
+import ExamsPage from './pages/ExamsPage'
 
 function ComingSoon({ title }: { title: string }) {
   return (
@@ -35,7 +36,7 @@ export default function App() {
           <Routes>
             <Route path="/"            element={<DashboardPage />} />
             <Route path="/students"    element={<ComingSoon title="Students" />} />
-            <Route path="/exams"       element={<ComingSoon title="Exams" />} />
+            <Route path="/exams"       element={<ExamsPage />} />
             <Route path="/homework"    element={<ComingSoon title="Homework" />} />
             <Route path="/grades"      element={<ComingSoon title="Grades" />} />
             <Route path="/paper-exams" element={<PaperExamsPage />} />

--- a/packages/frontend/src/features/exams/ExamCard.tsx
+++ b/packages/frontend/src/features/exams/ExamCard.tsx
@@ -1,0 +1,75 @@
+import type { CSSProperties } from 'react'
+import type { ExamTemplateListItem } from './examsTypes'
+
+interface ExamCardProps {
+  item: ExamTemplateListItem
+  onOpen: (examId: string) => void
+}
+
+function getStatusBadgeStyle(statusLabel: string): CSSProperties {
+  const normalized = statusLabel.trim().toLowerCase()
+
+  if (normalized === 'published') {
+    return {
+      color: 'var(--accent-teal)',
+      background: 'rgba(0, 201, 167, 0.1)',
+      border: '1px solid rgba(0, 201, 167, 0.2)',
+    }
+  }
+
+  if (normalized === 'archived') {
+    return {
+      color: 'var(--text-muted)',
+      background: 'rgba(120, 180, 220, 0.08)',
+      border: '1px solid rgba(120, 180, 220, 0.18)',
+    }
+  }
+
+  return {
+    color: 'var(--accent-gold)',
+    background: 'rgba(232, 164, 40, 0.1)',
+    border: '1px solid rgba(232, 164, 40, 0.2)',
+  }
+}
+
+export default function ExamCard({ item, onOpen }: ExamCardProps) {
+  return (
+    <article
+      className="card-glow flex h-full flex-col justify-between rounded-xl border bg-surface p-5"
+      style={{ borderColor: 'var(--border)' }}
+    >
+      <div className="space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <h3
+            className="min-w-0 flex-1 font-display text-base font-semibold text-pri"
+            title={item.title}
+          >
+            <span className="block truncate">{item.title}</span>
+          </h3>
+          <span
+            className="shrink-0 rounded-full px-2 py-0.5 font-mono text-xs font-medium"
+            style={getStatusBadgeStyle(item.statusLabel)}
+          >
+            {item.statusLabel}
+          </span>
+        </div>
+
+        <p className="font-body text-sm text-sec">
+          {item.questionCount} questions · {item.totalPoints} total points
+        </p>
+      </div>
+
+      <div className="mt-4">
+        <button
+          type="button"
+          onClick={() => onOpen(item.id)}
+          className="inline-flex items-center rounded-lg px-2 py-1 font-display text-sm font-semibold transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-gold)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)] active:scale-95"
+          style={{ color: 'var(--accent-gold)' }}
+          aria-label={`Manage exam ${item.title}`}
+        >
+          Manage Exam
+        </button>
+      </div>
+    </article>
+  )
+}

--- a/packages/frontend/src/features/exams/ExamsList.tsx
+++ b/packages/frontend/src/features/exams/ExamsList.tsx
@@ -1,0 +1,19 @@
+import type { ExamTemplateListItem } from './examsTypes'
+import ExamCard from './ExamCard'
+
+interface ExamsListProps {
+  items: ExamTemplateListItem[]
+  onOpenExam: (examId: string) => void
+}
+
+export default function ExamsList({ items, onOpenExam }: ExamsListProps) {
+  return (
+    <ul className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3" aria-label="Exam templates">
+      {items.map((item) => (
+        <li key={item.id} className="list-none">
+          <ExamCard item={item} onOpen={onOpenExam} />
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/packages/frontend/src/features/exams/ExamsStates.tsx
+++ b/packages/frontend/src/features/exams/ExamsStates.tsx
@@ -1,0 +1,100 @@
+interface EmptyExamsStateProps {
+  onCreateExam: () => void
+}
+
+interface ErrorExamsStateProps {
+  onRetry: () => void
+}
+
+export function LoadingExamsState() {
+  return (
+    <section aria-live="polite" aria-label="Loading exams" className="space-y-4">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <div
+            key={`exam-skeleton-${index}`}
+            className="h-32 animate-pulse rounded-xl bg-elevated"
+            aria-hidden="true"
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export function ErrorExamsState({ onRetry }: ErrorExamsStateProps) {
+  return (
+    <section
+      role="alert"
+      className="rounded-xl border p-5"
+      style={{
+        background: 'rgba(232, 69, 90, 0.08)',
+        borderColor: 'rgba(232, 69, 90, 0.22)',
+      }}
+    >
+      <div className="flex items-start gap-3">
+        <span className="text-lg" style={{ color: 'var(--accent-crimson)' }} aria-hidden="true">
+          ⚠
+        </span>
+        <div className="space-y-3">
+          <div>
+            <p className="font-display text-sm font-semibold" style={{ color: 'var(--accent-crimson)' }}>
+              Failed to load exams.
+            </p>
+            <p className="mt-0.5 font-body text-xs" style={{ color: 'var(--text-secondary)' }}>
+              There was a problem connecting to the server.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="inline-flex items-center rounded-lg border px-3 py-1.5 font-display text-xs font-semibold transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-crimson)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)] active:scale-95"
+            style={{
+              borderColor: 'var(--accent-crimson)',
+              color: 'var(--accent-crimson)',
+            }}
+          >
+            Try Again
+          </button>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export function EmptyExamsState({ onCreateExam }: EmptyExamsStateProps) {
+  return (
+    <section className="flex flex-col items-center justify-center gap-5 py-24 text-center">
+      <div
+        className="flex h-16 w-16 items-center justify-center rounded-xl text-2xl font-display font-bold"
+        style={{
+          background: 'rgba(232, 164, 40, 0.1)',
+          border: '1px solid rgba(232, 164, 40, 0.22)',
+          color: 'var(--accent-gold)',
+        }}
+        aria-hidden="true"
+      >
+        +
+      </div>
+      <div>
+        <p className="font-display text-base font-bold" style={{ color: 'var(--text-primary)' }}>
+          No exam templates found
+        </p>
+        <p className="mt-1 font-body text-sm" style={{ color: 'var(--text-secondary)' }}>
+          Create your first exam template to get started.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onCreateExam}
+        className="inline-flex items-center rounded-lg px-5 py-2.5 font-display text-sm font-semibold transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-gold)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)] active:scale-95"
+        style={{
+          background: 'var(--accent-gold)',
+          color: 'var(--bg-base)',
+        }}
+      >
+        + Create Exam
+      </button>
+    </section>
+  )
+}

--- a/packages/frontend/src/features/exams/examsApi.test.ts
+++ b/packages/frontend/src/features/exams/examsApi.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import api from '../../lib/api'
+import { fetchExamTemplates, toExamTemplateListItem } from './examsApi'
+
+vi.mock('../../lib/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}))
+
+const mockedGet = vi.mocked(api.get)
+
+describe('examsApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('maps optional missing fields to safe defaults', () => {
+    const mapped = toExamTemplateListItem({ id: 'exam-1', title: 'Midterm' })
+
+    expect(mapped).toEqual({
+      id: 'exam-1',
+      title: 'Midterm',
+      questionCount: 0,
+      totalPoints: 0,
+      statusLabel: 'Draft',
+    })
+  })
+
+  it('returns null for entries missing an identifier', () => {
+    expect(toExamTemplateListItem({ title: 'No Id' })).toBeNull()
+  })
+
+  it('enforces strict numeric parsing for number-like fields', () => {
+    const mapped = toExamTemplateListItem({
+      id: 'exam-2',
+      title: 'Final',
+      questionCount: '10.5',
+      totalPoints: '11e2',
+      status: 'Published',
+    })
+
+    expect(mapped).toEqual({
+      id: 'exam-2',
+      title: 'Final',
+      questionCount: 10.5,
+      totalPoints: 0,
+      statusLabel: 'Published',
+    })
+  })
+
+  it('extracts templates from wrapped payload and filters invalid rows', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        data: {
+          content: [
+            { id: 'exam-a', name: 'Quiz A', questionCount: '8', totalPoints: '20' },
+            { title: 'Missing id should be dropped' },
+          ],
+        },
+      },
+    })
+
+    const templates = await fetchExamTemplates()
+
+    expect(mockedGet).toHaveBeenCalledWith('/exam-templates')
+    expect(templates).toEqual([
+      {
+        id: 'exam-a',
+        title: 'Quiz A',
+        questionCount: 8,
+        totalPoints: 20,
+        statusLabel: 'Draft',
+      },
+    ])
+  })
+})

--- a/packages/frontend/src/features/exams/examsApi.ts
+++ b/packages/frontend/src/features/exams/examsApi.ts
@@ -1,0 +1,128 @@
+import api from '../../lib/api'
+import type { ApiResponse } from '../../lib/apiTypes'
+import type { ExamTemplateListItem, RawExamTemplate } from './examsTypes'
+
+const EXAM_TEMPLATES_ENDPOINT = '/exam-templates'
+const DEFAULT_TITLE = 'Untitled Exam'
+const DEFAULT_STATUS_LABEL = 'Draft'
+const DECIMAL_NUMBER_PATTERN = /^\d+(?:\.\d+)?$/
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function toStringOrDefault(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') {
+    return fallback
+  }
+
+  const normalized = value.trim()
+  return normalized.length > 0 ? normalized : fallback
+}
+
+function toFiniteNonNegativeNumber(value: unknown, fallback = 0): number {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value >= 0 ? value : fallback
+  }
+
+  if (typeof value !== 'string') {
+    return fallback
+  }
+
+  const normalized = value.trim()
+  if (normalized.length === 0 || !DECIMAL_NUMBER_PATTERN.test(normalized)) {
+    return fallback
+  }
+
+  const parsed = Number(normalized)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
+}
+
+function getTemplateListFromRecord(record: Record<string, unknown>): unknown[] {
+  const directKeys = ['items', 'templates', 'examTemplates', 'exams', 'content']
+
+  for (const key of directKeys) {
+    const maybeList = record[key]
+    if (Array.isArray(maybeList)) {
+      return maybeList
+    }
+  }
+
+  const data = record.data
+  if (Array.isArray(data)) {
+    return data
+  }
+
+  if (!isRecord(data)) {
+    return []
+  }
+
+  for (const key of directKeys) {
+    const maybeList = data[key]
+    if (Array.isArray(maybeList)) {
+      return maybeList
+    }
+  }
+
+  return []
+}
+
+function extractTemplateList(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) {
+    return payload
+  }
+
+  if (!isRecord(payload)) {
+    return []
+  }
+
+  return getTemplateListFromRecord(payload)
+}
+
+export function toExamTemplateListItem(raw: unknown): ExamTemplateListItem | null {
+  if (!isRecord(raw)) {
+    return null
+  }
+
+  const rawTemplate = raw as RawExamTemplate
+  const id = toStringOrDefault(
+    rawTemplate.id ?? rawTemplate.examTemplateId ?? rawTemplate.templateId,
+    '',
+  )
+
+  if (!id) {
+    return null
+  }
+
+  const title = toStringOrDefault(rawTemplate.title ?? rawTemplate.name, DEFAULT_TITLE)
+  const questionCount = toFiniteNonNegativeNumber(
+    rawTemplate.questionCount ?? rawTemplate.questions,
+    0,
+  )
+  const totalPoints = toFiniteNonNegativeNumber(rawTemplate.totalPoints, 0)
+  const statusLabel = toStringOrDefault(
+    rawTemplate.status ?? rawTemplate.label,
+    DEFAULT_STATUS_LABEL,
+  )
+
+  return {
+    id,
+    title,
+    questionCount,
+    totalPoints,
+    statusLabel,
+  }
+}
+
+export async function fetchExamTemplates(): Promise<ExamTemplateListItem[]> {
+  const response = await api.get<ApiResponse<unknown> | unknown>(EXAM_TEMPLATES_ENDPOINT)
+  const rawTemplates = extractTemplateList(response.data)
+
+  return rawTemplates
+    .map((rawTemplate) => toExamTemplateListItem(rawTemplate))
+    .filter((item): item is ExamTemplateListItem => item !== null)
+}
+
+export function isExamTemplateListEmpty(items: ExamTemplateListItem[]): boolean {
+  return items.length === 0
+}

--- a/packages/frontend/src/features/exams/examsTypes.ts
+++ b/packages/frontend/src/features/exams/examsTypes.ts
@@ -1,0 +1,20 @@
+export interface ExamTemplateListItem {
+  id: string
+  title: string
+  questionCount: number
+  totalPoints: number
+  statusLabel: string
+}
+
+export interface RawExamTemplate {
+  id?: string | null
+  examTemplateId?: string | null
+  templateId?: string | null
+  title?: string | null
+  name?: string | null
+  questionCount?: number | string | null
+  questions?: number | string | null
+  totalPoints?: number | string | null
+  status?: string | null
+  label?: string | null
+}

--- a/packages/frontend/src/pages/ExamsPage.test.tsx
+++ b/packages/frontend/src/pages/ExamsPage.test.tsx
@@ -1,0 +1,129 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import App from '../App'
+import ExamsPage from './ExamsPage'
+
+const fetchExamTemplatesMock = vi.fn()
+
+vi.mock('../features/exams/examsApi', () => ({
+  fetchExamTemplates: (...args: unknown[]) => fetchExamTemplatesMock(...args),
+  isExamTemplateListEmpty: (items: unknown[]) => items.length === 0,
+}))
+
+describe('ExamsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders loading state while templates are being fetched', () => {
+    fetchExamTemplatesMock.mockReturnValueOnce(new Promise(() => {}))
+
+    render(
+      <MemoryRouter>
+        <ExamsPage />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByLabelText('Loading exams')).toBeInTheDocument()
+  })
+
+  it('renders error state when template fetch fails', async () => {
+    fetchExamTemplatesMock.mockRejectedValueOnce(new Error('network error'))
+
+    render(
+      <MemoryRouter>
+        <ExamsPage />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('Failed to load exams.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument()
+  })
+
+  it('renders empty state when no templates are returned', async () => {
+    fetchExamTemplatesMock.mockResolvedValueOnce([])
+
+    render(
+      <MemoryRouter>
+        <ExamsPage />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('No exam templates found')).toBeInTheDocument()
+    expect(screen.getByText('Create your first exam template to get started.')).toBeInTheDocument()
+  })
+
+  it('renders populated list and supports per-item manage action', async () => {
+    fetchExamTemplatesMock.mockResolvedValueOnce([
+      {
+        id: 'exam-42',
+        title: 'Algebra Final',
+        questionCount: 20,
+        totalPoints: 100,
+        statusLabel: 'Published',
+      },
+    ])
+
+    window.history.pushState({}, '', '/exams')
+    render(<App />)
+
+    expect(await screen.findByText('Algebra Final')).toBeInTheDocument()
+    expect(screen.getByText('20 questions · 100 total points')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Manage exam Algebra Final' }))
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/paper-exams')
+      expect(window.location.search).toContain('examId=exam-42')
+    })
+  })
+
+  it('navigates to /paper-exams when Create Exam is clicked', async () => {
+    fetchExamTemplatesMock.mockResolvedValueOnce([])
+
+    window.history.pushState({}, '', '/exams')
+    render(<App />)
+
+    expect(await screen.findByText('No exam templates found')).toBeInTheDocument()
+
+    const createButtons = screen.getAllByRole('button', { name: '+ Create Exam' })
+    fireEvent.click(createButtons[0])
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/paper-exams')
+    })
+  })
+})
+
+describe('App routing non-regression', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders Exams page on /exams route', async () => {
+    fetchExamTemplatesMock.mockResolvedValueOnce([])
+
+    window.history.pushState({}, '', '/exams')
+    render(<App />)
+
+    expect(await screen.findByText('Manage your exam templates')).toBeInTheDocument()
+  })
+
+  it('still renders Paper Exams page on /paper-exams route', async () => {
+    fetchExamTemplatesMock.mockResolvedValue([])
+
+    window.history.pushState({}, '', '/paper-exams')
+    render(<App />)
+
+    expect(await screen.findByRole('heading', { name: 'Paper Exams', level: 1 })).toBeInTheDocument()
+  })
+})

--- a/packages/frontend/src/pages/ExamsPage.tsx
+++ b/packages/frontend/src/pages/ExamsPage.tsx
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import ExamsList from '../features/exams/ExamsList'
+import { EmptyExamsState, ErrorExamsState, LoadingExamsState } from '../features/exams/ExamsStates'
+import { fetchExamTemplates, isExamTemplateListEmpty } from '../features/exams/examsApi'
+import type { ExamTemplateListItem } from '../features/exams/examsTypes'
+
+type LoadState = 'loading' | 'error' | 'done'
+
+export default function ExamsPage() {
+  const navigate = useNavigate()
+  const [loadState, setLoadState] = useState<LoadState>('loading')
+  const [items, setItems] = useState<ExamTemplateListItem[]>([])
+  const latestRequestIdRef = useRef(0)
+  const isMountedRef = useRef(true)
+
+  const loadTemplates = useCallback(async () => {
+    const requestId = ++latestRequestIdRef.current
+    setLoadState('loading')
+
+    try {
+      const templates = await fetchExamTemplates()
+      if (!isMountedRef.current || requestId !== latestRequestIdRef.current) {
+        return
+      }
+
+      setItems(templates)
+      setLoadState('done')
+    } catch {
+      if (!isMountedRef.current || requestId !== latestRequestIdRef.current) {
+        return
+      }
+
+      setLoadState('error')
+    }
+  }, [])
+
+  useEffect(() => {
+    isMountedRef.current = true
+    void loadTemplates()
+
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [loadTemplates])
+
+  const handleCreateExam = useCallback(() => {
+    navigate('/paper-exams')
+  }, [navigate])
+
+  const handleOpenExam = useCallback(
+    (examId: string) => {
+      navigate(`/paper-exams?examId=${encodeURIComponent(examId)}`)
+    },
+    [navigate],
+  )
+
+  return (
+    <main className="flex-1 overflow-y-auto bg-base" style={{ padding: '40px', maxWidth: '1200px' }}>
+      <header className="mb-8 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div>
+          <h1 className="font-display text-2xl font-bold text-pri">Exams</h1>
+          <p className="mt-1 font-body text-sm text-sec">Manage your exam templates</p>
+        </div>
+        <button
+          type="button"
+          onClick={handleCreateExam}
+          className="inline-flex items-center justify-center self-start rounded-lg px-5 py-2.5 font-display text-sm font-semibold transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-gold)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)] active:scale-95"
+          style={{
+            background: 'var(--accent-gold)',
+            color: 'var(--bg-base)',
+          }}
+        >
+          + Create Exam
+        </button>
+      </header>
+
+      {loadState === 'loading' && <LoadingExamsState />}
+
+      {loadState === 'error' && <ErrorExamsState onRetry={() => void loadTemplates()} />}
+
+      {loadState === 'done' && isExamTemplateListEmpty(items) && (
+        <EmptyExamsState onCreateExam={handleCreateExam} />
+      )}
+
+      {loadState === 'done' && !isExamTemplateListEmpty(items) && (
+        <ExamsList items={items} onOpenExam={handleOpenExam} />
+      )}
+    </main>
+  )
+}

--- a/packages/frontend/src/test/setup.ts
+++ b/packages/frontend/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'

--- a/packages/frontend/vitest.config.ts
+++ b/packages/frontend/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+    css: true,
+  },
+})


### PR DESCRIPTION
## Summary
- add new  page and route wiring in app router
- implement exams feature UI states (loading/error/empty/populated) with card/list components
- add API adapter/types for exam templates with null-safe mapping and strict numeric parsing
- add focused tests with Vitest + Testing Library and test setup/config
- update README with FEAT-028 behavior and AC verification checklist

## Validation
- npm run lint
- npm run type-check
- npm run build
- npm run test:run

## Notes
- Deferred non-blocking follow-ups: ESLint config formatting readability and React Router future-flag test warning cleanup.