### PR TITLE
[FEAT-029] Build Students UI Page

### DIFF
--- a/packages/frontend/src/App.test.tsx
+++ b/packages/frontend/src/App.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import App from './App'
+
+vi.mock('./components/layout/TopNav', () => ({
+  default: () => <nav aria-label="Top navigation" />,
+}))
+
+vi.mock('./pages/DashboardPage', () => ({
+  default: () => <h1>Dashboard Mock Page</h1>,
+}))
+
+vi.mock('./pages/StudentsPage', () => ({
+  default: () => <h1>Students Mock Page</h1>,
+}))
+
+vi.mock('./pages/ExamsPage', () => ({
+  default: () => <h1>Exams Mock Page</h1>,
+}))
+
+vi.mock('./pages/PaperExamsPage', () => ({
+  default: () => <h1>Paper Exams Mock Page</h1>,
+}))
+
+vi.mock('./pages/ManualReviewQueuePage', () => ({
+  default: () => <h1>Review Mock Page</h1>,
+}))
+
+describe('App routes', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it.each([
+    ['/', 'Dashboard Mock Page'],
+    ['/students', 'Students Mock Page'],
+    ['/exams', 'Exams Mock Page'],
+    ['/paper-exams', 'Paper Exams Mock Page'],
+    ['/review', 'Review Mock Page'],
+    ['/homework', 'Homework'],
+    ['/grades', 'Grades'],
+  ])('renders %s route without regressions', (route, headingText) => {
+    window.history.pushState({}, '', route)
+
+    render(<App />)
+
+    expect(screen.getByRole('heading', { name: headingText })).toBeInTheDocument()
+  })
+})

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import PaperExamsPage from './pages/PaperExamsPage'
 import ManualReviewQueuePage from './pages/ManualReviewQueuePage'
 import DashboardPage from './pages/DashboardPage'
 import ExamsPage from './pages/ExamsPage'
+import StudentsPage from './pages/StudentsPage'
 
 function ComingSoon({ title }: { title: string }) {
   return (
@@ -35,7 +36,7 @@ export default function App() {
         <main style={{ flex: 1, overflowY: 'auto', backgroundColor: 'var(--bg-base)' }}>
           <Routes>
             <Route path="/"            element={<DashboardPage />} />
-            <Route path="/students"    element={<ComingSoon title="Students" />} />
+            <Route path="/students"    element={<StudentsPage />} />
             <Route path="/exams"       element={<ExamsPage />} />
             <Route path="/homework"    element={<ComingSoon title="Homework" />} />
             <Route path="/grades"      element={<ComingSoon title="Grades" />} />

--- a/packages/frontend/src/features/students/StudentsList.tsx
+++ b/packages/frontend/src/features/students/StudentsList.tsx
@@ -1,0 +1,73 @@
+import type { StudentListItem } from './studentsTypes'
+
+interface StudentsListProps {
+  items: StudentListItem[]
+}
+
+interface StudentCardProps {
+  item: StudentListItem
+}
+
+function StudentCard({ item }: StudentCardProps) {
+  const hasEmail = Boolean(item.email)
+  const hasStudentNumber = Boolean(item.studentNumber)
+  const hasClassLabel = Boolean(item.classLabel)
+  const hasGradeLabel = Boolean(item.gradeLabel)
+
+  return (
+    <article className="card-glow flex h-full flex-col justify-between rounded-xl border bg-surface p-5">
+      <div className="space-y-3">
+        <p className="truncate font-display text-base font-semibold text-pri" title={item.fullName}>
+          {item.fullName}
+        </p>
+
+        <div className="space-y-1.5">
+          <p className="font-body text-sm text-sec">{hasEmail ? item.email : 'No email provided'}</p>
+
+          {(hasStudentNumber || hasClassLabel || hasGradeLabel || item.isActive) && (
+            <div className="flex flex-wrap gap-2">
+              {hasStudentNumber && (
+                <span className="rounded-full border px-2 py-0.5 font-body text-xs text-sec">
+                  #{item.studentNumber}
+                </span>
+              )}
+              {hasClassLabel && (
+                <span className="rounded-full border px-2 py-0.5 font-body text-xs text-sec">
+                  Class: {item.classLabel}
+                </span>
+              )}
+              {hasGradeLabel && (
+                <span className="rounded-full border px-2 py-0.5 font-body text-xs text-sec">
+                  Grade: {item.gradeLabel}
+                </span>
+              )}
+              {item.isActive && (
+                <span
+                  className="rounded-full border px-2 py-0.5 font-body text-xs"
+                  style={{
+                    borderColor: 'rgba(232, 164, 40, 0.35)',
+                    color: 'var(--accent-gold)',
+                  }}
+                >
+                  Active
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </article>
+  )
+}
+
+export default function StudentsList({ items }: StudentsListProps) {
+  return (
+    <ul className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3" aria-label="Students">
+      {items.map((item) => (
+        <li key={item.id} className="list-none">
+          <StudentCard item={item} />
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/packages/frontend/src/features/students/StudentsStates.tsx
+++ b/packages/frontend/src/features/students/StudentsStates.tsx
@@ -1,0 +1,106 @@
+interface ErrorStudentsStateProps {
+  onRetry: () => void
+  message: string
+  canRetry: boolean
+}
+
+export function LoadingStudentsState() {
+  return (
+    <section aria-live="polite" aria-label="Loading students" className="space-y-4">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <div
+            key={`student-skeleton-${index}`}
+            className="h-32 animate-pulse rounded-xl bg-elevated"
+            aria-hidden="true"
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export function ErrorStudentsState({ onRetry, message, canRetry }: ErrorStudentsStateProps) {
+  return (
+    <section
+      role="alert"
+      className="rounded-xl border p-5"
+      style={{
+        background: 'rgba(232, 69, 90, 0.08)',
+        borderColor: 'rgba(232, 69, 90, 0.22)',
+      }}
+    >
+      <div className="flex items-start gap-3">
+        <span className="text-lg" style={{ color: 'var(--accent-crimson)' }} aria-hidden="true">
+          ⚠
+        </span>
+        <div className="space-y-3">
+          <div>
+            <p className="font-display text-sm font-semibold" style={{ color: 'var(--accent-crimson)' }}>
+              Failed to load students.
+            </p>
+            <p className="mt-0.5 font-body text-xs" style={{ color: 'var(--text-secondary)' }}>
+              {message}
+            </p>
+          </div>
+          {canRetry ? (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="inline-flex items-center rounded-lg border px-3 py-1.5 font-display text-xs font-semibold transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-gold)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-base)] active:scale-95"
+              style={{
+                borderColor: 'var(--accent-crimson)',
+                color: 'var(--accent-crimson)',
+              }}
+              aria-label="Retry loading students"
+            >
+              Try Again
+            </button>
+          ) : (
+            <p className="font-body text-xs" style={{ color: 'var(--text-secondary)' }}>
+              Update your configuration and refresh this page.
+            </p>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export function EmptyStudentsState() {
+  return (
+    <section className="flex flex-col items-center justify-center gap-5 py-24 text-center">
+      <div
+        className="flex h-16 w-16 items-center justify-center rounded-xl text-2xl font-display font-bold"
+        style={{
+          background: 'rgba(232, 164, 40, 0.1)',
+          border: '1px solid rgba(232, 164, 40, 0.22)',
+          color: 'var(--accent-gold)',
+        }}
+        aria-hidden="true"
+      >
+        +
+      </div>
+      <div>
+        <p className="font-display text-base font-bold" style={{ color: 'var(--text-primary)' }}>
+          No students found
+        </p>
+        <p className="mt-1 font-body text-sm" style={{ color: 'var(--text-secondary)' }}>
+          Students added to the system will appear here.
+        </p>
+      </div>
+      <button
+        type="button"
+        disabled
+        className="inline-flex cursor-not-allowed items-center rounded-lg px-5 py-2.5 font-display text-sm font-semibold opacity-60"
+        style={{
+          background: 'var(--accent-gold)',
+          color: 'var(--bg-base)',
+        }}
+        aria-label="Add student unavailable"
+      >
+        + Add Student
+      </button>
+    </section>
+  )
+}

--- a/packages/frontend/src/features/students/studentsApi.test.ts
+++ b/packages/frontend/src/features/students/studentsApi.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+import api from '../../lib/api'
+import { fetchStudents, isValidSchoolId, isStudentListEmpty } from './studentsApi'
+
+vi.mock('../../lib/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}))
+
+const VALID_SCHOOL_ID = '123e4567-e89b-12d3-a456-426614174000'
+
+describe('studentsApi', () => {
+  const originalSchoolId = import.meta.env.VITE_SCHOOL_ID
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    import.meta.env.VITE_SCHOOL_ID = VALID_SCHOOL_ID
+  })
+
+  afterAll(() => {
+    if (originalSchoolId === undefined) {
+      delete import.meta.env.VITE_SCHOOL_ID
+      return
+    }
+
+    import.meta.env.VITE_SCHOOL_ID = originalSchoolId
+  })
+
+  describe('fetchStudents', () => {
+    it('should use the shared api client to fetch scoped students', async () => {
+      vi.mocked(api.get).mockResolvedValueOnce({ data: [] })
+      await fetchStudents()
+      expect(api.get).toHaveBeenCalledWith(`/schools/${encodeURIComponent(VALID_SCHOOL_ID)}/students`)
+    })
+
+    it('should fail closed when VITE_SCHOOL_ID is missing', async () => {
+      delete import.meta.env.VITE_SCHOOL_ID
+
+      await expect(fetchStudents()).rejects.toThrow(
+        'Students cannot be loaded because school configuration is missing. Set VITE_SCHOOL_ID and reload the page.'
+      )
+      expect(api.get).not.toHaveBeenCalled()
+    })
+
+    it('should fail closed when VITE_SCHOOL_ID is invalid', async () => {
+      import.meta.env.VITE_SCHOOL_ID = 'invalid-school-id'
+
+      await expect(fetchStudents()).rejects.toThrow(
+        'Students cannot be loaded because school configuration is invalid. Set VITE_SCHOOL_ID to a valid school UUID and reload the page.'
+      )
+      expect(api.get).not.toHaveBeenCalled()
+    })
+
+    it('should handle a successful response with a list of students', async () => {
+      const mockData = [
+        { id: '1', firstName: 'John', lastName: 'Doe', email: 'john@example.com', studentNumber: 'S001', isActive: true },
+        { id: '2', fullName: 'Jane Smith', email: 'jane@example.com', studentNumber: 'S002', isActive: false },
+      ]
+      vi.mocked(api.get).mockResolvedValueOnce({ data: mockData })
+
+      const result = await fetchStudents()
+
+      expect(result).toHaveLength(2)
+      expect(result[0]).toEqual({
+        id: '1',
+        fullName: 'John Doe',
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john@example.com',
+        studentNumber: 'S001',
+        classLabel: null,
+        gradeLabel: null,
+        isActive: true,
+      })
+      expect(result[1]).toEqual({
+        id: '2',
+        fullName: 'Jane Smith',
+        firstName: null,
+        lastName: null,
+        email: 'jane@example.com',
+        studentNumber: 'S002',
+        classLabel: null,
+        gradeLabel: null,
+        isActive: false,
+      })
+    })
+
+    it('should safely handle malformed records (missing id)', async () => {
+      const mockData = [
+        { firstName: 'No ID' }, // Should be filtered out
+        { id: '3', firstName: 'Valid', lastName: 'ID' },
+      ]
+      vi.mocked(api.get).mockResolvedValueOnce({ data: mockData })
+
+      const result = await fetchStudents()
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('3')
+    })
+
+    it('should safely handle incomplete records (missing optional fields)', async () => {
+      const mockData = [
+        { id: '4' }, // Only ID provided
+      ]
+      vi.mocked(api.get).mockResolvedValueOnce({ data: mockData })
+
+      const result = await fetchStudents()
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual({
+        id: '4',
+        fullName: 'Unnamed Student',
+        firstName: null,
+        lastName: null,
+        email: null,
+        studentNumber: null,
+        classLabel: null,
+        gradeLabel: null,
+        isActive: true, // Default fallback
+      })
+    })
+
+    it('should extract student list from various payload envelopes', async () => {
+      const mockData = {
+        data: {
+          items: [{ id: '5', fullName: 'Envelope Student' }]
+        }
+      }
+      vi.mocked(api.get).mockResolvedValueOnce({ data: mockData })
+
+      const result = await fetchStudents()
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe('5')
+    })
+
+    it('should handle non-array payloads gracefully', async () => {
+      vi.mocked(api.get).mockResolvedValueOnce({ data: null })
+      const result1 = await fetchStudents()
+      expect(result1).toEqual([])
+
+      vi.mocked(api.get).mockResolvedValueOnce({ data: 'string payload' })
+      const result2 = await fetchStudents()
+      expect(result2).toEqual([])
+    })
+  })
+
+  describe('isValidSchoolId', () => {
+    it('should return true for valid UUIDs', () => {
+      expect(isValidSchoolId('123e4567-e89b-12d3-a456-426614174000')).toBe(true)
+      expect(isValidSchoolId('018f4f3e-4a8e-7b21-8e8b-f13a0e3f9abc')).toBe(true)
+    })
+
+    it('should return false for invalid UUIDs', () => {
+      expect(isValidSchoolId('invalid-id')).toBe(false)
+      expect(isValidSchoolId('')).toBe(false)
+    })
+  })
+
+  describe('isStudentListEmpty', () => {
+    it('should return true for empty list', () => {
+      expect(isStudentListEmpty([])).toBe(true)
+    })
+
+    it('should return false for non-empty list', () => {
+      expect(
+        isStudentListEmpty([
+          {
+            id: '1',
+            fullName: 'Test',
+            firstName: null,
+            lastName: null,
+            email: null,
+            studentNumber: null,
+            classLabel: null,
+            gradeLabel: null,
+            isActive: true,
+          },
+        ])
+      ).toBe(false)
+    })
+  })
+})

--- a/packages/frontend/src/features/students/studentsApi.ts
+++ b/packages/frontend/src/features/students/studentsApi.ts
@@ -1,0 +1,246 @@
+import api from '../../lib/api'
+import type { ApiResponse } from '../../lib/apiTypes'
+import type { RawStudent, StudentListItem } from './studentsTypes'
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const DEFAULT_STUDENT_NAME = 'Unnamed Student'
+
+export class NonRetryableStudentsError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'NonRetryableStudentsError'
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function toTrimmedString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim()
+  return normalized.length > 0 ? normalized : null
+}
+
+function toNullableString(value: unknown): string | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value)
+  }
+
+  return toTrimmedString(value)
+}
+
+function toBoolean(value: unknown, fallback = true): boolean {
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (normalized === 'true') {
+      return true
+    }
+
+    if (normalized === 'false') {
+      return false
+    }
+  }
+
+  return fallback
+}
+
+function toMetadataLabel(value: unknown): string | null {
+  const directValue = toNullableString(value)
+  if (directValue) {
+    return directValue
+  }
+
+  if (!isRecord(value)) {
+    return null
+  }
+
+  return (
+    toNullableString(value.label) ??
+    toNullableString(value.name) ??
+    toNullableString(value.title) ??
+    toNullableString(value.value)
+  )
+}
+
+function firstMetadataLabel(values: unknown[]): string | null {
+  for (const value of values) {
+    const label = toMetadataLabel(value)
+    if (label) {
+      return label
+    }
+  }
+
+  return null
+}
+
+function extractStudentListFromRecord(record: Record<string, unknown>): unknown[] {
+  const directKeys = ['items', 'students', 'content']
+
+  for (const key of directKeys) {
+    const maybeList = record[key]
+    if (Array.isArray(maybeList)) {
+      return maybeList
+    }
+  }
+
+  const data = record.data
+  if (Array.isArray(data)) {
+    return data
+  }
+
+  if (!isRecord(data)) {
+    return []
+  }
+
+  for (const key of directKeys) {
+    const maybeList = data[key]
+    if (Array.isArray(maybeList)) {
+      return maybeList
+    }
+  }
+
+  return []
+}
+
+function extractStudentList(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) {
+    return payload
+  }
+
+  if (!isRecord(payload)) {
+    return []
+  }
+
+  return extractStudentListFromRecord(payload)
+}
+
+function buildFullName(rawStudent: RawStudent): string {
+  const explicitName = toTrimmedString(rawStudent.fullName ?? rawStudent.name)
+  if (explicitName) {
+    return explicitName
+  }
+
+  const firstName = toTrimmedString(rawStudent.firstName)
+  const lastName = toTrimmedString(rawStudent.lastName)
+  const combinedName = [firstName, lastName].filter(Boolean).join(' ')
+
+  return combinedName || DEFAULT_STUDENT_NAME
+}
+
+export function isValidSchoolId(schoolId: string): boolean {
+  return UUID_PATTERN.test(schoolId.trim())
+}
+
+export function toStudentListItem(raw: unknown): StudentListItem | null {
+  if (!isRecord(raw)) {
+    return null
+  }
+
+  const rawStudent = raw as RawStudent
+  const id = toNullableString(rawStudent.id ?? rawStudent.studentId)
+
+  if (!id) {
+    return null
+  }
+
+  const firstName = toNullableString(rawStudent.firstName)
+  const lastName = toNullableString(rawStudent.lastName)
+  const metadata = isRecord(rawStudent.metadata) ? rawStudent.metadata : null
+
+  const classLabel = firstMetadataLabel([
+    rawStudent.classLabel,
+    rawStudent.className,
+    rawStudent.classroom,
+    rawStudent.classRoom,
+    rawStudent.homeroom,
+    rawStudent.classInfo,
+    rawStudent.classMetadata,
+    rawStudent.class,
+    metadata?.classLabel,
+    metadata?.className,
+    metadata?.classroom,
+    metadata?.homeroom,
+    metadata?.class,
+  ])
+
+  const gradeLabel = firstMetadataLabel([
+    rawStudent.gradeLevel,
+    rawStudent.gradeName,
+    rawStudent.grade,
+    rawStudent.yearLevel,
+    rawStudent.year,
+    rawStudent.gradeInfo,
+    metadata?.gradeLevel,
+    metadata?.gradeName,
+    metadata?.grade,
+    metadata?.yearLevel,
+    metadata?.year,
+  ])
+
+  return {
+    id,
+    fullName: buildFullName(rawStudent),
+    firstName,
+    lastName,
+    email: toNullableString(rawStudent.email),
+    studentNumber: toNullableString(rawStudent.studentNumber ?? rawStudent.rollNumber),
+    classLabel,
+    gradeLabel,
+    isActive: toBoolean(rawStudent.isActive ?? rawStudent.active, true),
+  }
+}
+
+function resolveStudentsEndpoint(): string {
+  const normalizedSchoolId = import.meta.env.VITE_SCHOOL_ID?.trim() ?? ''
+
+  if (!normalizedSchoolId) {
+    throw new NonRetryableStudentsError(
+      'Students cannot be loaded because school configuration is missing. Set VITE_SCHOOL_ID and reload the page.'
+    )
+  }
+
+  if (!isValidSchoolId(normalizedSchoolId)) {
+    throw new NonRetryableStudentsError(
+      'Students cannot be loaded because school configuration is invalid. Set VITE_SCHOOL_ID to a valid school UUID and reload the page.'
+    )
+  }
+
+  const encodedSchoolId = encodeURIComponent(normalizedSchoolId)
+  return `/schools/${encodedSchoolId}/students`
+}
+
+export async function fetchStudents(): Promise<StudentListItem[]> {
+  const endpoint = resolveStudentsEndpoint()
+  const response = await api.get<ApiResponse<unknown> | unknown>(endpoint)
+  const rawStudents = extractStudentList(response.data)
+
+  return rawStudents
+    .map((rawStudent) => toStudentListItem(rawStudent))
+    .filter((item): item is StudentListItem => item !== null)
+}
+
+export function isStudentListEmpty(items: StudentListItem[]): boolean {
+  return items.length === 0
+}
+
+export function getStudentsLoadErrorDetails(error: unknown): { message: string; retryable: boolean } {
+  if (error instanceof NonRetryableStudentsError) {
+    return {
+      message: error.message,
+      retryable: false,
+    }
+  }
+
+  return {
+    message: 'There was a problem connecting to the server.',
+    retryable: true,
+  }
+}

--- a/packages/frontend/src/features/students/studentsTypes.ts
+++ b/packages/frontend/src/features/students/studentsTypes.ts
@@ -1,0 +1,40 @@
+export interface StudentListItem {
+  id: string
+  fullName: string
+  firstName: string | null
+  lastName: string | null
+  email: string | null
+  studentNumber: string | null
+  classLabel: string | null
+  gradeLabel: string | null
+  isActive: boolean
+}
+
+export interface RawStudent {
+  id?: unknown
+  studentId?: unknown
+  fullName?: unknown
+  name?: unknown
+  firstName?: unknown
+  lastName?: unknown
+  email?: unknown
+  studentNumber?: unknown
+  rollNumber?: unknown
+  className?: unknown
+  classLabel?: unknown
+  classRoom?: unknown
+  classroom?: unknown
+  homeroom?: unknown
+  classInfo?: unknown
+  classMetadata?: unknown
+  class?: unknown
+  grade?: unknown
+  gradeName?: unknown
+  gradeLevel?: unknown
+  yearLevel?: unknown
+  year?: unknown
+  gradeInfo?: unknown
+  metadata?: unknown
+  isActive?: unknown
+  active?: unknown
+}

--- a/packages/frontend/src/pages/StudentsPage.test.tsx
+++ b/packages/frontend/src/pages/StudentsPage.test.tsx
@@ -1,0 +1,144 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import App from '../App'
+import StudentsPage from './StudentsPage'
+
+const fetchStudentsMock = vi.fn()
+const getStudentsLoadErrorDetailsMock = vi.fn((error: unknown) => ({
+  message: error instanceof Error ? error.message : 'There was a problem connecting to the server.',
+  retryable: true,
+}))
+
+vi.mock('../features/students/studentsApi', () => ({
+  fetchStudents: (...args: unknown[]) => fetchStudentsMock(...args),
+  isStudentListEmpty: (items: unknown[]) => items.length === 0,
+  getStudentsLoadErrorDetails: (...args: unknown[]) => getStudentsLoadErrorDetailsMock(...args),
+}))
+
+describe('StudentsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getStudentsLoadErrorDetailsMock.mockImplementation((error: unknown) => ({
+      message: error instanceof Error ? error.message : 'There was a problem connecting to the server.',
+      retryable: true,
+    }))
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders loading state while students are being fetched', () => {
+    fetchStudentsMock.mockReturnValueOnce(new Promise(() => {}))
+
+    render(
+      <MemoryRouter>
+        <StudentsPage />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByLabelText('Loading students')).toBeInTheDocument()
+  })
+
+  it('renders error state when student fetch fails', async () => {
+    fetchStudentsMock.mockRejectedValueOnce(new Error('network error'))
+
+    render(
+      <MemoryRouter>
+        <StudentsPage />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('Failed to load students.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Retry loading students' })).toBeInTheDocument()
+  })
+
+  it('renders empty state when no students are returned', async () => {
+    fetchStudentsMock.mockResolvedValueOnce([])
+
+    render(
+      <MemoryRouter>
+        <StudentsPage />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('No students found')).toBeInTheDocument()
+    expect(screen.getByText('Students added to the system will appear here.')).toBeInTheDocument()
+  })
+
+  it('renders populated list and handles missing optional fields safely', async () => {
+    fetchStudentsMock.mockResolvedValueOnce([
+      {
+        id: 'student-1',
+        fullName: 'Alice Smith',
+        email: 'alice@example.com',
+        studentNumber: '12345',
+        classLabel: 'Math 101',
+        gradeLabel: 'A',
+        isActive: true,
+      },
+      {
+        id: 'student-2',
+        fullName: 'Bob Jones',
+        // Missing optional fields
+      },
+    ])
+
+    render(
+      <MemoryRouter>
+        <StudentsPage />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('Alice Smith')).toBeInTheDocument()
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument()
+    expect(screen.getByText('#12345')).toBeInTheDocument()
+    expect(screen.getByText('Class: Math 101')).toBeInTheDocument()
+    expect(screen.getByText('Grade: A')).toBeInTheDocument()
+    expect(screen.getByText('Active')).toBeInTheDocument()
+
+    expect(screen.getByText('Bob Jones')).toBeInTheDocument()
+    expect(screen.getByText('No email provided')).toBeInTheDocument()
+  })
+
+  it('retries fetching students when Try Again is clicked', async () => {
+    fetchStudentsMock.mockRejectedValueOnce(new Error('network error'))
+    fetchStudentsMock.mockResolvedValueOnce([])
+
+    render(
+      <MemoryRouter>
+        <StudentsPage />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('Failed to load students.')).toBeInTheDocument()
+    
+    const retryButton = screen.getByRole('button', { name: 'Retry loading students' })
+    fireEvent.click(retryButton)
+
+    expect(await screen.findByText('No students found')).toBeInTheDocument()
+    expect(fetchStudentsMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('renders non-retryable error state without retry action', async () => {
+    fetchStudentsMock.mockRejectedValueOnce(new Error('invalid config'))
+    getStudentsLoadErrorDetailsMock.mockReturnValueOnce({
+      message: 'Students cannot be loaded because school configuration is invalid. Set VITE_SCHOOL_ID to a valid school UUID and reload the page.',
+      retryable: false,
+    })
+
+    render(
+      <MemoryRouter>
+        <StudentsPage />
+      </MemoryRouter>,
+    )
+
+    expect(
+      await screen.findByText(
+        'Students cannot be loaded because school configuration is invalid. Set VITE_SCHOOL_ID to a valid school UUID and reload the page.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Retry loading students' })).not.toBeInTheDocument()
+  })
+})

--- a/packages/frontend/src/pages/StudentsPage.tsx
+++ b/packages/frontend/src/pages/StudentsPage.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import StudentsList from '../features/students/StudentsList'
+import { EmptyStudentsState, ErrorStudentsState, LoadingStudentsState } from '../features/students/StudentsStates'
+import { fetchStudents, getStudentsLoadErrorDetails, isStudentListEmpty } from '../features/students/studentsApi'
+import type { StudentListItem } from '../features/students/studentsTypes'
+
+type LoadState = 'loading' | 'error' | 'done'
+
+export default function StudentsPage() {
+  const [loadState, setLoadState] = useState<LoadState>('loading')
+  const [items, setItems] = useState<StudentListItem[]>([])
+  const [errorMessage, setErrorMessage] = useState('There was a problem connecting to the server.')
+  const [canRetry, setCanRetry] = useState(true)
+  const latestRequestIdRef = useRef(0)
+  const isMountedRef = useRef(true)
+
+  const loadStudents = useCallback(async () => {
+    const requestId = ++latestRequestIdRef.current
+    setLoadState('loading')
+
+    try {
+      const students = await fetchStudents()
+      if (!isMountedRef.current || requestId !== latestRequestIdRef.current) {
+        return
+      }
+
+      setItems(students)
+      setErrorMessage('There was a problem connecting to the server.')
+      setCanRetry(true)
+      setLoadState('done')
+    } catch (error) {
+      if (!isMountedRef.current || requestId !== latestRequestIdRef.current) {
+        return
+      }
+
+      const details = getStudentsLoadErrorDetails(error)
+      setErrorMessage(details.message)
+      setCanRetry(details.retryable)
+      setLoadState('error')
+    }
+  }, [])
+
+  useEffect(() => {
+    isMountedRef.current = true
+    void loadStudents()
+
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [loadStudents])
+
+  return (
+    <main className="flex-1 overflow-y-auto bg-base" style={{ padding: '40px', maxWidth: '1200px' }}>
+      <header className="mb-8 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div>
+          <h1 className="font-display text-2xl font-bold text-pri">Students</h1>
+          <p className="mt-1 font-body text-sm text-sec">Manage your students</p>
+        </div>
+        <button
+          type="button"
+          disabled
+          className="inline-flex cursor-not-allowed items-center justify-center self-start rounded-lg px-5 py-2.5 font-display text-sm font-semibold opacity-60"
+          style={{
+            background: 'var(--accent-gold)',
+            color: 'var(--bg-base)',
+          }}
+          aria-label="Add student unavailable"
+        >
+          + Add Student
+        </button>
+      </header>
+
+      {loadState === 'loading' && <LoadingStudentsState />}
+
+      {loadState === 'error' && (
+        <ErrorStudentsState
+          onRetry={() => void loadStudents()}
+          message={errorMessage}
+          canRetry={canRetry}
+        />
+      )}
+
+      {loadState === 'done' && isStudentListEmpty(items) && <EmptyStudentsState />}
+
+      {loadState === 'done' && !isStudentListEmpty(items) && <StudentsList items={items} />}
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- Replace `/students` placeholder route with `StudentsPage`
- Add students feature API/types module using shared Axios client
- Implement loading/error/empty/populated page states with retry behavior
- Add route-level and feature tests for students flow and non-regression routes
- Enforce fail-closed tenant scoping for `VITE_SCHOOL_ID`

## Validation
- `cd packages/frontend && npm run test -- --run`
- `cd packages/frontend && npm run build`

## Backlog Link
- FEAT-029 (Build Students UI Page)
