### PR TITLE
[FEAT-030] Wire PaperExamsPage to Real Exam Templates & Students

### DIFF
--- a/packages/frontend/src/features/exams/examsApi.test.ts
+++ b/packages/frontend/src/features/exams/examsApi.test.ts
@@ -20,6 +20,7 @@ describe('examsApi', () => {
 
     expect(mapped).toEqual({
       id: 'exam-1',
+      assignmentId: 'exam-1',
       title: 'Midterm',
       questionCount: 0,
       totalPoints: 0,
@@ -42,6 +43,7 @@ describe('examsApi', () => {
 
     expect(mapped).toEqual({
       id: 'exam-2',
+      assignmentId: 'exam-2',
       title: 'Final',
       questionCount: 10.5,
       totalPoints: 0,
@@ -67,6 +69,7 @@ describe('examsApi', () => {
     expect(templates).toEqual([
       {
         id: 'exam-a',
+        assignmentId: 'exam-a',
         title: 'Quiz A',
         questionCount: 8,
         totalPoints: 20,

--- a/packages/frontend/src/features/exams/examsApi.ts
+++ b/packages/frontend/src/features/exams/examsApi.ts
@@ -94,6 +94,11 @@ export function toExamTemplateListItem(raw: unknown): ExamTemplateListItem | nul
     return null
   }
 
+  const assignmentId = toStringOrDefault(
+    rawTemplate.assignmentId ?? rawTemplate.assignmentUUID ?? rawTemplate.assignment_id,
+    id,
+  )
+
   const title = toStringOrDefault(rawTemplate.title ?? rawTemplate.name, DEFAULT_TITLE)
   const questionCount = toFiniteNonNegativeNumber(
     rawTemplate.questionCount ?? rawTemplate.questions,
@@ -107,6 +112,7 @@ export function toExamTemplateListItem(raw: unknown): ExamTemplateListItem | nul
 
   return {
     id,
+    assignmentId,
     title,
     questionCount,
     totalPoints,

--- a/packages/frontend/src/features/exams/examsTypes.ts
+++ b/packages/frontend/src/features/exams/examsTypes.ts
@@ -1,5 +1,6 @@
 export interface ExamTemplateListItem {
   id: string
+  assignmentId: string
   title: string
   questionCount: number
   totalPoints: number
@@ -10,6 +11,9 @@ export interface RawExamTemplate {
   id?: string | null
   examTemplateId?: string | null
   templateId?: string | null
+  assignmentId?: string | null
+  assignmentUUID?: string | null
+  assignment_id?: string | null
   title?: string | null
   name?: string | null
   questionCount?: number | string | null

--- a/packages/frontend/src/pages/PaperExamsPage.test.tsx
+++ b/packages/frontend/src/pages/PaperExamsPage.test.tsx
@@ -1,0 +1,146 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import PaperExamsPage from './PaperExamsPage'
+
+const fetchExamTemplatesMock = vi.fn()
+const fetchStudentsMock = vi.fn()
+const getStudentsLoadErrorDetailsMock = vi.fn(() => ({
+  message: 'There was a problem connecting to the server.',
+  retryable: true,
+}))
+
+vi.mock('../features/exams/examsApi', () => ({
+  fetchExamTemplates: (...args: unknown[]) => fetchExamTemplatesMock(...args),
+}))
+
+vi.mock('../features/students/studentsApi', () => ({
+  fetchStudents: (...args: unknown[]) => fetchStudentsMock(...args),
+  getStudentsLoadErrorDetails: (...args: unknown[]) => getStudentsLoadErrorDetailsMock(...args),
+}))
+
+vi.mock('../features/submissions/FileUpload', () => ({
+  default: ({ assignmentId, studentId }: { assignmentId: string; studentId: string }) => (
+    <div data-testid="file-upload-props">
+      assignmentId={assignmentId};studentId={studentId}
+    </div>
+  ),
+}))
+
+vi.mock('../features/grading/useGrading', () => ({
+  useGrading: () => ({
+    state: { phase: 'idle' as const },
+    grade: vi.fn(),
+    reset: vi.fn(),
+  }),
+}))
+
+vi.mock('../features/grading/GradingResultCard', () => ({
+  default: () => null,
+}))
+
+vi.mock('../features/grading/GradingResultsList', () => ({
+  default: () => null,
+}))
+
+describe('PaperExamsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders exam templates and student dropdown from APIs without demo data', async () => {
+    fetchExamTemplatesMock.mockResolvedValueOnce([
+      {
+        id: 'template-1',
+        assignmentId: 'assignment-42',
+        title: 'Algebra Midterm',
+        questionCount: 12,
+        totalPoints: 60,
+        statusLabel: 'Published',
+      },
+    ])
+    fetchStudentsMock.mockResolvedValueOnce([
+      {
+        id: 'student-1',
+        fullName: 'Alice Smith',
+      },
+      {
+        id: 'student-2',
+        fullName: 'Jordan Lee',
+      },
+    ])
+
+    render(
+      <MemoryRouter>
+        <PaperExamsPage />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('Algebra Midterm')).toBeInTheDocument()
+    expect(screen.queryByText('Exam from Uploaded Image')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '✏ Grade' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Alice Smith' })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'Jordan Lee' })).toBeInTheDocument()
+    })
+
+    expect(screen.queryByRole('option', { name: 'Jack' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'Sarah' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'Mohammed' })).not.toBeInTheDocument()
+  })
+
+  it('passes template-derived assignmentId to file upload instead of nil uuid', async () => {
+    fetchExamTemplatesMock.mockResolvedValueOnce([
+      {
+        id: 'template-9',
+        assignmentId: 'assignment-real-9',
+        title: 'Physics Quiz',
+        questionCount: 5,
+        totalPoints: 25,
+        statusLabel: 'Draft',
+      },
+    ])
+    fetchStudentsMock.mockResolvedValueOnce([
+      {
+        id: 'student-9',
+        fullName: 'Mia Torres',
+      },
+    ])
+
+    render(
+      <MemoryRouter>
+        <PaperExamsPage />
+      </MemoryRouter>,
+    )
+
+    await screen.findByText('Physics Quiz')
+    fireEvent.click(screen.getByRole('button', { name: '✏ Grade' }))
+    fireEvent.change(screen.getByLabelText('Select Student to Grade'), {
+      target: { value: 'student-9' },
+    })
+
+    expect(await screen.findByTestId('file-upload-props')).toHaveTextContent('assignmentId=assignment-real-9')
+    expect(screen.getByTestId('file-upload-props')).not.toHaveTextContent('00000000-0000-0000-0000-000000000001')
+  })
+
+  it('renders exam and student empty-state guidance links', async () => {
+    fetchExamTemplatesMock.mockResolvedValueOnce([])
+    fetchStudentsMock.mockResolvedValueOnce([])
+
+    render(
+      <MemoryRouter>
+        <PaperExamsPage />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('No exam templates available')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Create exam template' })).toHaveAttribute('href', '/exams')
+    expect(screen.getByRole('link', { name: 'Add students' })).toHaveAttribute('href', '/students')
+  })
+})

--- a/packages/frontend/src/pages/PaperExamsPage.tsx
+++ b/packages/frontend/src/pages/PaperExamsPage.tsx
@@ -1,34 +1,34 @@
-import { useCallback, useEffect, useState } from 'react'
-import FileUpload from '../features/submissions/FileUpload'
-import GradingResultCard from '../features/grading/GradingResultCard'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { fetchExamTemplates } from '../features/exams/examsApi'
+import type { ExamTemplateListItem } from '../features/exams/examsTypes'
 import type { SavedScore } from '../features/grading/GradingResultCard'
+import GradingResultCard from '../features/grading/GradingResultCard'
 import GradingResultsList from '../features/grading/GradingResultsList'
 import type { GradedStudentRecord } from '../features/grading/GradingResultsList'
 import { useGrading } from '../features/grading/useGrading'
+import {
+  fetchStudents,
+  getStudentsLoadErrorDetails,
+} from '../features/students/studentsApi'
+import type { StudentListItem } from '../features/students/studentsTypes'
+import FileUpload from '../features/submissions/FileUpload'
 
-// Placeholder exam data until the exam entity API is wired up
-const DEMO_EXAMS = [
-  {
-    id: 'exam-001',
-    title: 'Exam from Uploaded Image',
-    tag: 'From Image',
-    questions: 3,
-    totalPoints: 20,
-  },
-]
-
-// Placeholder students
-const DEMO_STUDENTS = [
-  { id: 'stu-001', name: 'Jack' },
-  { id: 'stu-002', name: 'Sarah' },
-  { id: 'stu-003', name: 'Mohammed' },
-]
-
-// Fixed demo assignment id until assignment entity is implemented
-const DEMO_ASSIGNMENT_ID = '00000000-0000-0000-0000-000000000001'
-
-// ── Empty state ───────────────────────────────────────────────────────────────
-function EmptyState({ onCreateClick }: { onCreateClick: () => void }) {
+function EmptyState({
+  title,
+  description,
+  primaryLinkLabel,
+  primaryLinkTo,
+  secondaryLinkLabel,
+  secondaryLinkTo,
+}: {
+  title: string
+  description: string
+  primaryLinkLabel: string
+  primaryLinkTo: string
+  secondaryLinkLabel?: string
+  secondaryLinkTo?: string
+}) {
   return (
     <div className="flex flex-col items-center justify-center py-24 gap-5">
       <div
@@ -43,34 +43,47 @@ function EmptyState({ onCreateClick }: { onCreateClick: () => void }) {
       </div>
       <div className="text-center">
         <p className="font-display font-bold text-base" style={{ color: 'var(--text-primary)' }}>
-          No paper exams yet
+          {title}
         </p>
         <p className="text-sm mt-1 font-body" style={{ color: 'var(--text-secondary)' }}>
-          Create your first paper exam with custom questions or upload an image
+          {description}
         </p>
       </div>
-      <button
-        onClick={onCreateClick}
-        className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg font-display font-semibold text-sm transition-colors"
-        style={{
-          background: 'var(--accent-gold)',
-          color: '#06101e',
-        }}
-      >
-        + Create Your First Paper Exam
-      </button>
+      <div className="flex flex-wrap justify-center gap-3">
+        <Link
+          to={primaryLinkTo}
+          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg font-display font-semibold text-sm transition-colors"
+          style={{
+            background: 'var(--accent-gold)',
+            color: '#06101e',
+          }}
+        >
+          {primaryLinkLabel}
+        </Link>
+        {secondaryLinkLabel && secondaryLinkTo && (
+          <Link
+            to={secondaryLinkTo}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg font-display font-semibold text-sm transition-colors"
+            style={{
+              border: '1px solid var(--border)',
+              color: 'var(--text-secondary)',
+            }}
+          >
+            {secondaryLinkLabel}
+          </Link>
+        )}
+      </div>
     </div>
   )
 }
 
-// ── Exam card ────────────────────────────────────────────────────────────────
 function ExamCard({
   exam,
   gradedCount,
   totalStudents,
   onGrade,
 }: {
-  exam: (typeof DEMO_EXAMS)[0]
+  exam: ExamTemplateListItem
   gradedCount: number
   totalStudents: number
   onGrade: () => void
@@ -99,11 +112,11 @@ function ExamCard({
                 border: '1px solid rgba(91, 197, 245, 0.2)',
               }}
             >
-              {exam.tag}
+              {exam.statusLabel}
             </span>
           </div>
           <p className="font-mono text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
-            {exam.questions} questions · {exam.totalPoints} total points
+            {exam.questionCount} questions · {exam.totalPoints} total points
           </p>
         </div>
         <button
@@ -128,7 +141,7 @@ function ExamCard({
           role="progressbar"
           aria-valuenow={gradedCount}
           aria-valuemin={0}
-          aria-valuemax={totalStudents}
+          aria-valuemax={Math.max(totalStudents, 1)}
           aria-label={`${gradedCount} of ${totalStudents} students graded`}
         >
           <div
@@ -142,20 +155,29 @@ function ExamCard({
       </div>
 
       <button className="mt-3 text-xs transition-colors font-mono" style={{ color: 'var(--text-muted)' }}>
-        ◈ View {exam.questions} questions
+        ◈ View {exam.questionCount} questions
       </button>
     </div>
   )
 }
 
-// ── Grade panel ───────────────────────────────────────────────────────────────
 function GradePanel({
-  examTitle,
+  exam,
+  students,
+  studentsLoading,
+  studentsError,
+  studentsRetryable,
+  onRetryStudents,
   gradedStudents,
   onBack,
   onSaveGrades,
 }: {
-  examTitle: string
+  exam: ExamTemplateListItem
+  students: StudentListItem[]
+  studentsLoading: boolean
+  studentsError: string | null
+  studentsRetryable: boolean
+  onRetryStudents: () => void
   gradedStudents: GradedStudentRecord[]
   onBack: () => void
   onSaveGrades: (record: GradedStudentRecord) => void
@@ -164,26 +186,37 @@ function GradePanel({
   const [submissionId, setSubmissionId] = useState<string | null>(null)
   const { state: gradingState, grade, reset } = useGrading()
 
-  const selectedStudent = DEMO_STUDENTS.find((s) => s.id === selectedStudentId)
-  const gradedStudentIds = new Set(gradedStudents.map((g) => g.studentId))
-  const ungradedStudents = DEMO_STUDENTS.filter((s) => !gradedStudentIds.has(s.id))
+  const selectedStudent = useMemo(
+    () => students.find((student) => student.id === selectedStudentId) ?? null,
+    [selectedStudentId, students],
+  )
+  const gradedStudentIds = useMemo(
+    () => new Set(gradedStudents.map((gradedStudent) => gradedStudent.studentId)),
+    [gradedStudents],
+  )
+  const ungradedStudents = useMemo(
+    () => students.filter((student) => !gradedStudentIds.has(student.id)),
+    [students, gradedStudentIds],
+  )
 
   useEffect(() => {
     setSubmissionId(null)
     reset()
   }, [selectedStudentId, reset])
 
-  const handleUploadComplete = useCallback((sid: string) => {
-    setSubmissionId((prev) => prev ?? sid)
+  const handleUploadComplete = useCallback((uploadedSubmissionId: string) => {
+    setSubmissionId((currentSubmissionId) => currentSubmissionId ?? uploadedSubmissionId)
   }, [])
 
   function handleSaveGrades(savedScores: SavedScore[]) {
     if (!selectedStudent || gradingState.phase !== 'success') return
-    const totalAdjusted = savedScores.reduce((s, sc) => s + sc.adjustedPoints, 0)
-    const totalAvailable = gradingState.parsedQuestions.reduce((s, q) => s + q.pointsAvailable, 0)
+
+    const totalAdjusted = savedScores.reduce((sum, score) => sum + score.adjustedPoints, 0)
+    const totalAvailable = gradingState.parsedQuestions.reduce((sum, question) => sum + question.pointsAvailable, 0)
+
     onSaveGrades({
       studentId: selectedStudent.id,
-      studentName: selectedStudent.name,
+      studentName: selectedStudent.fullName,
       submissionId: submissionId ?? '',
       result: gradingState.result,
       parsedQuestions: gradingState.parsedQuestions,
@@ -191,6 +224,7 @@ function GradePanel({
       totalAdjusted,
       totalAvailable,
     })
+
     setSubmissionId(null)
     setSelectedStudentId('')
     reset()
@@ -209,14 +243,13 @@ function GradePanel({
         border: '1px solid var(--border)',
       }}
     >
-      {/* Header */}
       <div className="flex items-start justify-between">
         <div>
           <h2 className="font-display font-bold text-lg" style={{ color: 'var(--text-primary)' }}>
             Grade Paper Exam
           </h2>
           <p className="font-body text-sm mt-0.5" style={{ color: 'var(--text-secondary)' }}>
-            {examTitle}
+            {exam.title}
           </p>
         </div>
         <button
@@ -227,14 +260,13 @@ function GradePanel({
             color: 'var(--text-secondary)',
             background: 'transparent',
           }}
-          onMouseEnter={e => ((e.currentTarget as HTMLElement).style.background = 'rgba(120, 180, 220, 0.06)')}
-          onMouseLeave={e => ((e.currentTarget as HTMLElement).style.background = 'transparent')}
+          onMouseEnter={(event) => ((event.currentTarget as HTMLElement).style.background = 'rgba(120, 180, 220, 0.06)')}
+          onMouseLeave={(event) => ((event.currentTarget as HTMLElement).style.background = 'transparent')}
         >
           ← Back to Exams
         </button>
       </div>
 
-      {/* Summary */}
       <div
         className="rounded-lg p-4 flex items-center justify-between text-sm"
         style={{
@@ -245,20 +277,19 @@ function GradePanel({
         <div className="space-y-0.5 font-mono" style={{ color: 'var(--text-secondary)' }}>
           <p>
             <span className="font-semibold" style={{ color: 'var(--text-primary)' }}>Total Points:</span>{' '}
-            20
+            {exam.totalPoints}
           </p>
           <p>
             <span className="font-semibold" style={{ color: 'var(--text-primary)' }}>Questions:</span>{' '}
-            3
+            {exam.questionCount}
           </p>
         </div>
         <p className="font-mono" style={{ color: 'var(--text-secondary)' }}>
           <span className="font-semibold" style={{ color: 'var(--text-primary)' }}>Graded:</span>{' '}
-          {gradedStudents.length}/{DEMO_STUDENTS.length}
+          {gradedStudents.length}/{students.length}
         </p>
       </div>
 
-      {/* Student selector */}
       <div className="space-y-1.5">
         <label htmlFor="student-select" className="font-display text-sm font-medium" style={{ color: 'var(--text-secondary)' }}>
           Select Student to Grade
@@ -266,29 +297,69 @@ function GradePanel({
         <select
           id="student-select"
           value={selectedStudentId}
-          onChange={(e) => setSelectedStudentId(e.target.value)}
+          onChange={(event) => setSelectedStudentId(event.target.value)}
+          disabled={studentsLoading || !!studentsError || ungradedStudents.length === 0}
           className="w-full rounded-lg px-3 py-2 text-sm focus:outline-none transition-colors font-body"
           style={{
             backgroundColor: 'var(--bg-elevated)',
             border: `1px solid ${selectedStudentId ? 'rgba(232, 164, 40, 0.4)' : 'var(--border)'}`,
             color: selectedStudentId ? 'var(--text-primary)' : 'var(--text-muted)',
+            opacity: studentsLoading ? 0.7 : 1,
           }}
         >
           <option value="">Choose a student…</option>
-          {ungradedStudents.map((s) => (
-            <option key={s.id} value={s.id}>{s.name}</option>
+          {ungradedStudents.map((student) => (
+            <option key={student.id} value={student.id}>{student.fullName}</option>
           ))}
           {gradedStudents.length > 0 && (
             <optgroup label="Already graded">
-              {gradedStudents.map((g) => (
-                <option key={g.studentId} value={g.studentId}>{g.studentName} ✓</option>
+              {gradedStudents.map((gradedStudent) => (
+                <option key={gradedStudent.studentId} value={gradedStudent.studentId}>{gradedStudent.studentName} ✓</option>
               ))}
             </optgroup>
           )}
         </select>
+
+        {studentsLoading && (
+          <p className="font-body text-xs" style={{ color: 'var(--text-secondary)' }}>
+            Loading students…
+          </p>
+        )}
+
+        {studentsError && (
+          <div
+            className="rounded-lg p-3 space-y-1.5"
+            role="alert"
+            style={{
+              background: 'rgba(232, 69, 90, 0.08)',
+              border: '1px solid rgba(232, 69, 90, 0.25)',
+            }}
+          >
+            <p className="font-display font-semibold text-sm" style={{ color: 'var(--accent-crimson)' }}>
+              Failed to load students
+            </p>
+            <p className="font-body text-xs" style={{ color: 'var(--text-secondary)' }}>
+              {studentsError}
+            </p>
+            {studentsRetryable && (
+              <button onClick={onRetryStudents} className="text-xs underline" style={{ color: 'var(--accent-crimson)' }}>
+                Retry loading students
+              </button>
+            )}
+          </div>
+        )}
+
+        {!studentsLoading && !studentsError && ungradedStudents.length === 0 && (
+          <p className="font-body text-xs" style={{ color: 'var(--text-secondary)' }}>
+            No students available for grading yet.{' '}
+            <Link to="/students" className="underline" style={{ color: 'var(--accent-gold)' }}>
+              Add students
+            </Link>
+            .
+          </p>
+        )}
       </div>
 
-      {/* Upload area */}
       {selectedStudent && (
         <div
           className="rounded-xl p-5 space-y-4"
@@ -304,13 +375,13 @@ function GradePanel({
                 Upload Student's Handwritten Exam
               </h3>
               <p className="font-body text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
-                Upload a picture of {selectedStudent.name}'s completed exam for AI-powered grading.
+                Upload a picture of {selectedStudent.fullName}'s completed exam for AI-powered grading.
               </p>
             </div>
           </div>
 
           <FileUpload
-            assignmentId={DEMO_ASSIGNMENT_ID}
+            assignmentId={exam.assignmentId}
             studentId={selectedStudent.id}
             onUploadComplete={handleUploadComplete}
           />
@@ -364,45 +435,93 @@ function GradePanel({
         </div>
       )}
 
-      {/* Grading result */}
-      {gradingState.phase === 'success' && (
+      {gradingState.phase === 'success' && selectedStudent && (
         <div className="space-y-2">
           <GradingResultCard
             result={gradingState.result}
             parsedQuestions={gradingState.parsedQuestions}
-            studentName={selectedStudent?.name ?? 'Student'}
+            studentName={selectedStudent.fullName}
             onSave={handleSaveGrades}
             onCancel={handleCancel}
           />
         </div>
       )}
 
-      {/* Graded results list */}
-      {gradedStudents.length > 0 && (
-        <GradingResultsList records={gradedStudents} />
-      )}
+      {gradedStudents.length > 0 && <GradingResultsList records={gradedStudents} />}
     </div>
   )
 }
 
-// ── Page ─────────────────────────────────────────────────────────────────────
 export default function PaperExamsPage() {
-  const [showExams] = useState(true)
   const [gradingExamId, setGradingExamId] = useState<string | null>(null)
   const [gradedStudents, setGradedStudents] = useState<GradedStudentRecord[]>([])
 
-  const gradingExam = DEMO_EXAMS.find((e) => e.id === gradingExamId) ?? null
+  const [exams, setExams] = useState<ExamTemplateListItem[]>([])
+  const [examsLoading, setExamsLoading] = useState(true)
+  const [examsError, setExamsError] = useState<string | null>(null)
+
+  const [students, setStudents] = useState<StudentListItem[]>([])
+  const [studentsLoading, setStudentsLoading] = useState(true)
+  const [studentsError, setStudentsError] = useState<string | null>(null)
+  const [studentsRetryable, setStudentsRetryable] = useState(true)
+
+  const gradingExam = useMemo(
+    () => exams.find((exam) => exam.id === gradingExamId) ?? null,
+    [exams, gradingExamId],
+  )
 
   function handleSaveGrades(record: GradedStudentRecord) {
-    setGradedStudents((prev) => {
-      const filtered = prev.filter((g) => g.studentId !== record.studentId)
-      return [...filtered, record]
+    setGradedStudents((previousRecords) => {
+      const otherRecords = previousRecords.filter((gradedStudent) => gradedStudent.studentId !== record.studentId)
+      return [...otherRecords, record]
     })
   }
 
+  const loadExams = useCallback(async () => {
+    setExamsLoading(true)
+    setExamsError(null)
+
+    try {
+      const templates = await fetchExamTemplates()
+      setExams(templates)
+    } catch (error) {
+      setExamsError(error instanceof Error ? error.message : 'Failed to load exam templates.')
+      setExams([])
+    } finally {
+      setExamsLoading(false)
+    }
+  }, [])
+
+  const loadStudents = useCallback(async () => {
+    setStudentsLoading(true)
+    setStudentsError(null)
+    setStudentsRetryable(true)
+
+    try {
+      const loadedStudents = await fetchStudents()
+      setStudents(loadedStudents)
+    } catch (error) {
+      const details = getStudentsLoadErrorDetails(error)
+      setStudentsError(details.message)
+      setStudentsRetryable(details.retryable)
+      setStudents([])
+    } finally {
+      setStudentsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadExams()
+    void loadStudents()
+  }, [loadExams, loadStudents])
+
+  const gradedCount = useMemo(
+    () => gradedStudents.filter((record) => students.some((student) => student.id === record.studentId)).length,
+    [gradedStudents, students],
+  )
+
   return (
     <div style={{ padding: '40px', maxWidth: '860px' }}>
-      {/* Page header */}
       <div className="flex items-start justify-between" style={{ marginBottom: '28px' }}>
         <div>
           <p
@@ -415,20 +534,20 @@ export default function PaperExamsPage() {
             Paper Exams
           </h1>
           <p className="font-body text-sm" style={{ color: 'var(--text-secondary)' }}>
-            Create custom exams with AI-powered handwriting recognition &amp; grading
+            Grade real student submissions using your existing exam templates.
           </p>
         </div>
         {!gradingExam && (
-          <button
+          <Link
+            to="/exams"
             className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg font-display font-semibold text-sm transition-colors flex-shrink-0"
             style={{ background: 'var(--accent-gold)', color: '#06101e' }}
           >
             + Create Paper Exam
-          </button>
+          </Link>
         )}
       </div>
 
-      {/* AI features callout */}
       {!gradingExam && (
         <div
           className="rounded-xl p-5"
@@ -445,38 +564,79 @@ export default function PaperExamsPage() {
             </p>
           </div>
           <ul className="space-y-1.5 font-body text-xs" style={{ color: 'var(--text-secondary)' }}>
-            <li>· Build custom exams with multiple choice or free-response questions</li>
-            <li>· Upload exam images to auto-generate questions via OCR</li>
-            <li>· Grade student exams by uploading handwritten answer images</li>
-            <li>· Confidence scoring flags submissions below 95% for your review</li>
+            <li>· Select from your real exam templates</li>
+            <li>· Upload handwritten student submissions for each template</li>
+            <li>· Trigger AI grading with confidence scoring and review support</li>
+            <li>· Save adjusted grades for each student submission</li>
           </ul>
         </div>
       )}
 
-      {/* Content */}
       {gradingExam ? (
         <GradePanel
-          examTitle={gradingExam.title}
+          exam={gradingExam}
+          students={students}
+          studentsLoading={studentsLoading}
+          studentsError={studentsError}
+          studentsRetryable={studentsRetryable}
+          onRetryStudents={loadStudents}
           gradedStudents={gradedStudents}
           onBack={() => setGradingExamId(null)}
           onSaveGrades={handleSaveGrades}
         />
-      ) : showExams ? (
+      ) : examsLoading ? (
+        <div
+          className="rounded-xl p-6 font-body text-sm"
+          role="status"
+          aria-live="polite"
+          style={{
+            backgroundColor: 'var(--bg-surface)',
+            border: '1px solid var(--border)',
+            color: 'var(--text-secondary)',
+          }}
+        >
+          Loading exam templates…
+        </div>
+      ) : examsError ? (
+        <div
+          className="rounded-xl p-6 space-y-2"
+          role="alert"
+          style={{
+            background: 'rgba(232, 69, 90, 0.08)',
+            border: '1px solid rgba(232, 69, 90, 0.25)',
+          }}
+        >
+          <p className="font-display font-semibold text-sm" style={{ color: 'var(--accent-crimson)' }}>
+            Failed to load exam templates
+          </p>
+          <p className="font-body text-xs" style={{ color: 'var(--text-secondary)' }}>
+            {examsError}
+          </p>
+          <button onClick={loadExams} className="text-xs underline" style={{ color: 'var(--accent-crimson)' }}>
+            Retry loading exam templates
+          </button>
+        </div>
+      ) : exams.length === 0 ? (
+        <EmptyState
+          title="No exam templates available"
+          description="Create your first template before grading paper submissions."
+          primaryLinkLabel="Create exam template"
+          primaryLinkTo="/exams"
+          secondaryLinkLabel="Add students"
+          secondaryLinkTo="/students"
+        />
+      ) : (
         <div className="space-y-4">
-          {DEMO_EXAMS.map((exam) => (
+          {exams.map((exam) => (
             <ExamCard
               key={exam.id}
               exam={exam}
-              gradedCount={gradedStudents.filter((g) =>
-                DEMO_STUDENTS.some((s) => s.id === g.studentId),
-              ).length}
-              totalStudents={DEMO_STUDENTS.length}
+              gradedCount={gradedCount}
+              totalStudents={students.length}
               onGrade={() => setGradingExamId(exam.id)}
             />
           ))}
         </div>
-      ) : (
-        <EmptyState onCreateClick={() => {}} />
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- replace demo paper-exam constants with real API data from `fetchExamTemplates()` and `fetchStudents()`
- derive upload `assignmentId` from selected template mapping (fallback to template id)
- add loading, retry/error, and empty-state UX for exam templates and student list
- remove hardcoded demo names/IDs from Paper Exams grading flow
- add focused tests for API wiring, assignment id behavior, and empty-state links

## Validation
- `cd packages/frontend && npm run test -- --run src/features/exams/examsApi.test.ts src/pages/PaperExamsPage.test.tsx`
- `cd packages/frontend && npm run build`

Closes #49
