### PR TITLE
fix: add grading providers and restore S3 previews

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,8 +131,10 @@ services:
       CLOUDWATCH_NAMESPACE: TraceGrade/Grading
       CLOUDWATCH_STEP_SECONDS: "60"
 
-      # OpenAI Configuration
+      # AI Provider Configuration
       OPENAI_API_KEY: ${OPENAI_API_KEY}
+      GEMINI_API_KEY: ${GEMINI_API_KEY}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
 
       # Security
       SECURITY_HTTPS_REDIRECT: "false"

--- a/packages/backend/src/main/java/com/tracegrade/domain/model/User.java
+++ b/packages/backend/src/main/java/com/tracegrade/domain/model/User.java
@@ -26,6 +26,8 @@ import lombok.Setter;
 import java.math.BigDecimal;
 import java.util.Locale;
 
+import com.tracegrade.grading.GradingProvider;
+
 @Entity
 @Table(name = "users")
 @Getter
@@ -75,6 +77,12 @@ public class User extends BaseEntity {
     @Digits(integer = 1, fraction = 2, message = "Confidence threshold must have at most 2 decimal places")
     @Column(name = "confidence_threshold", precision = 3, scale = 2)
     private BigDecimal confidenceThreshold;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "grading_provider", nullable = false, length = 50, columnDefinition = "VARCHAR(50) DEFAULT 'GEMINI_FLASH'")
+    @Builder.Default
+    private GradingProvider gradingProvider = GradingProvider.GEMINI_FLASH;
 
     @PrePersist
     @PreUpdate

--- a/packages/backend/src/main/java/com/tracegrade/exception/GlobalExceptionHandler.java
+++ b/packages/backend/src/main/java/com/tracegrade/exception/GlobalExceptionHandler.java
@@ -25,10 +25,12 @@ import com.tracegrade.dto.response.ApiResponse;
 import com.tracegrade.dto.response.FieldError;
 import com.tracegrade.imageprocessing.PreprocessingException;
 import com.tracegrade.grading.GradingFailedException;
+import com.tracegrade.grading.GradingProviderException;
 import com.tracegrade.grading.RubricSetupRequiredException;
 import com.tracegrade.openai.exception.OpenAiException;
 import com.tracegrade.openai.exception.OpenAiRateLimitException;
 import com.tracegrade.rubric.DuplicateQuestionNumberException;
+import com.tracegrade.settings.GradingProviderService;
 
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -291,6 +293,21 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.BAD_GATEWAY)
                 .body(ApiResponse.error(error));
     }
+
+        @ExceptionHandler(GradingProviderService.ProviderNotConfiguredApiException.class)
+        public ResponseEntity<ApiResponse<Void>> handleProviderNotConfigured(
+                        GradingProviderService.ProviderNotConfiguredApiException ex) {
+                log.warn("Provider not configured: provider={}", ex.getProvider());
+                ApiError error = ApiError.of("PROVIDER_NOT_CONFIGURED", ex.getMessage());
+                return ResponseEntity.badRequest().body(ApiResponse.error(error));
+        }
+
+        @ExceptionHandler(GradingProviderException.class)
+        public ResponseEntity<ApiResponse<Void>> handleGradingProviderException(GradingProviderException ex) {
+                log.error("Grading provider [{}] failed: {}", ex.getProvider(), ex.getMessage(), ex);
+                ApiError error = ApiError.of("AI_ERROR", "AI service encountered an error");
+                return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(ApiResponse.error(error));
+        }
 
     @ExceptionHandler(GradingFailedException.class)
     public ResponseEntity<ApiResponse<Void>> handleGradingFailed(GradingFailedException ex) {

--- a/packages/backend/src/main/java/com/tracegrade/grading/AIGradingService.java
+++ b/packages/backend/src/main/java/com/tracegrade/grading/AIGradingService.java
@@ -1,0 +1,12 @@
+package com.tracegrade.grading;
+
+import com.tracegrade.openai.dto.GradingRequest;
+import com.tracegrade.openai.dto.GradingResponse;
+
+/**
+ * Common contract for all AI grading providers.
+ */
+public interface AIGradingService {
+
+    GradingResponse gradeSubmission(GradingRequest request);
+}

--- a/packages/backend/src/main/java/com/tracegrade/grading/ClaudeSonnetGradingService.java
+++ b/packages/backend/src/main/java/com/tracegrade/grading/ClaudeSonnetGradingService.java
@@ -1,0 +1,220 @@
+package com.tracegrade.grading;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Base64;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tracegrade.openai.dto.GradingRequest;
+import com.tracegrade.openai.dto.GradingResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class ClaudeSonnetGradingService implements AIGradingService {
+
+    private static final String API_URL = "https://api.anthropic.com/v1/messages";
+    private static final String MODEL = "claude-sonnet-4-6";
+    private static final String ANTHROPIC_VERSION = "2023-06-01";
+
+    @Value("${ANTHROPIC_API_KEY:}")
+    private String apiKey;
+
+    private final ObjectMapper objectMapper;
+    private final HttpClient httpClient;
+
+    public ClaudeSonnetGradingService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(30))
+                .build();
+    }
+
+    @Override
+    public GradingResponse gradeSubmission(GradingRequest request) {
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new ProviderNotConfiguredException(GradingProvider.CLAUDE_SONNET);
+        }
+
+        log.info("Grading with Claude Sonnet: questionNumber={}", request.getQuestionNumber());
+
+        try {
+            String requestBody = buildRequestBody(request);
+
+            HttpRequest httpRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(API_URL))
+                    .header("Content-Type", "application/json")
+                    .header("x-api-key", apiKey)
+                    .header("anthropic-version", ANTHROPIC_VERSION)
+                    .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                    .timeout(Duration.ofSeconds(60))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() != 200) {
+                log.error("Claude API error: status={} body={}", response.statusCode(), response.body());
+                throw new GradingProviderException(GradingProvider.CLAUDE_SONNET,
+                        "HTTP " + response.statusCode() + " from Claude API");
+            }
+
+            return parseResponse(response.body(), request);
+        } catch (ProviderNotConfiguredException | GradingProviderException e) {
+            throw e;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Claude API call interrupted for questionNumber={}", request.getQuestionNumber(), e);
+            throw new GradingProviderException(GradingProvider.CLAUDE_SONNET, e.getMessage());
+        } catch (Exception e) {
+            log.error("Claude API call failed for questionNumber={}: {}", request.getQuestionNumber(), e.getMessage(), e);
+            throw new GradingProviderException(GradingProvider.CLAUDE_SONNET, e.getMessage());
+        }
+    }
+
+    private String buildRequestBody(GradingRequest request) throws Exception {
+        var userContent = new java.util.ArrayList<Object>();
+
+        userContent.add(java.util.Map.of("type", "text", "text", buildGradingPrompt(request)));
+
+        ImageData imageData = fetchImageData(request.getSubmissionImageUrl());
+        userContent.add(java.util.Map.of(
+                "type", "image",
+                "source", java.util.Map.of(
+                        "type", "base64",
+                        "media_type", imageData.mimeType(),
+                        "data", imageData.base64()
+                )
+        ));
+
+        if (request.getExpectedAnswerImageUrl() != null && !request.getExpectedAnswerImageUrl().isBlank()) {
+            userContent.add(java.util.Map.of("type", "text",
+                    "text", "A teacher-provided model answer image is attached next. Use it as rubric context."));
+            ImageData answerImage = fetchImageData(request.getExpectedAnswerImageUrl());
+            userContent.add(java.util.Map.of(
+                    "type", "image",
+                    "source", java.util.Map.of(
+                            "type", "base64",
+                            "media_type", answerImage.mimeType(),
+                            "data", answerImage.base64()
+                    )
+            ));
+        }
+
+        var body = java.util.Map.of(
+                "model", MODEL,
+                "max_tokens", 1000,
+                "system", buildSystemPrompt(),
+                "messages", java.util.List.of(
+                        java.util.Map.of("role", "user", "content", userContent)
+                )
+        );
+
+        return objectMapper.writeValueAsString(body);
+    }
+
+    private GradingResponse parseResponse(String responseBody, GradingRequest request) {
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+            String text = root.path("content").get(0).path("text").asText();
+
+            text = text.trim();
+            if (text.startsWith("```")) {
+                text = text.replaceAll("^```[a-z]*\\n?", "").replaceAll("```$", "").trim();
+            }
+
+            JsonNode node = objectMapper.readTree(text);
+            boolean illegible = node.has("illegible") && node.get("illegible").booleanValue();
+
+            int promptTokens = root.path("usage").path("input_tokens").asInt(0);
+            int completionTokens = root.path("usage").path("output_tokens").asInt(0);
+
+            return GradingResponse.builder()
+                    .questionNumber(request.getQuestionNumber())
+                    .pointsAwarded(node.get("pointsAwarded").decimalValue())
+                    .pointsAvailable(request.getPointsAvailable())
+                    .confidenceScore(node.get("confidenceScore").doubleValue())
+                    .feedback(node.get("feedback").asText())
+                    .illegible(illegible)
+                    .promptTokensUsed(promptTokens)
+                    .completionTokensUsed(completionTokens)
+                    .build();
+        } catch (Exception e) {
+            log.error("Failed to parse Claude grading response: {}", responseBody, e);
+            throw new GradingProviderException(GradingProvider.CLAUDE_SONNET, "Failed to parse response: " + e.getMessage());
+        }
+    }
+
+    private String buildSystemPrompt() {
+        return """
+                You are an expert grader. Analyze handwritten student answers in images.
+                Respond in strict JSON format with these exact fields:
+                pointsAwarded (number), feedback (string),
+                confidenceScore (number between 0.0 and 1.0), illegible (boolean).
+                If the handwriting cannot be read, set illegible=true and pointsAwarded=0.
+                Return only valid JSON, no markdown fences.
+                """;
+    }
+
+    private String buildGradingPrompt(GradingRequest req) {
+        return String.format(
+                """
+                Grade the handwritten answer in the image for question %d.
+                Expected answer: %s
+                Teacher model answer image attached: %s
+                Acceptable variations: %s
+                Grading notes: %s
+                Points available: %s
+                Respond with JSON only.
+                """,
+                req.getQuestionNumber(),
+                req.getExpectedAnswer(),
+                req.getExpectedAnswerImageUrl() != null && !req.getExpectedAnswerImageUrl().isBlank() ? "yes" : "no",
+                req.getAcceptableVariations() != null ? req.getAcceptableVariations() : "none specified",
+                req.getGradingNotes() != null ? req.getGradingNotes() : "none",
+                req.getPointsAvailable());
+    }
+
+    private ImageData fetchImageData(String url) throws IOException, InterruptedException {
+        if (url.startsWith("data:")) {
+            return parseDataUri(url);
+        }
+
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .GET()
+                .timeout(Duration.ofSeconds(30))
+                .build();
+
+        HttpResponse<byte[]> response = httpClient.send(req, HttpResponse.BodyHandlers.ofByteArray());
+        if (response.statusCode() != 200) {
+            throw new IOException("Failed to fetch image: HTTP " + response.statusCode());
+        }
+
+        String contentType = response.headers().firstValue("Content-Type").orElse("image/png");
+        String mimeType = contentType.split(";")[0].trim();
+        String base64 = Base64.getEncoder().encodeToString(response.body());
+        return new ImageData(mimeType, base64);
+    }
+
+    private ImageData parseDataUri(String dataUri) {
+        int commaIndex = dataUri.indexOf(',');
+        if (commaIndex < 0) {
+            return new ImageData("image/png", dataUri);
+        }
+        String header = dataUri.substring(5, commaIndex);
+        String base64 = dataUri.substring(commaIndex + 1);
+        String mimeType = header.contains(";") ? header.substring(0, header.indexOf(';')) : header;
+        return new ImageData(mimeType, base64);
+    }
+
+    private record ImageData(String mimeType, String base64) {}
+}

--- a/packages/backend/src/main/java/com/tracegrade/grading/GeminiGradingService.java
+++ b/packages/backend/src/main/java/com/tracegrade/grading/GeminiGradingService.java
@@ -1,0 +1,215 @@
+package com.tracegrade.grading;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Base64;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tracegrade.openai.dto.GradingRequest;
+import com.tracegrade.openai.dto.GradingResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class GeminiGradingService implements AIGradingService {
+
+    private static final String API_URL =
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
+
+    @Value("${GEMINI_API_KEY:}")
+    private String apiKey;
+
+    private final ObjectMapper objectMapper;
+    private final HttpClient httpClient;
+
+    public GeminiGradingService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(30))
+                .build();
+    }
+
+    @Override
+    public GradingResponse gradeSubmission(GradingRequest request) {
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new ProviderNotConfiguredException(GradingProvider.GEMINI_FLASH);
+        }
+
+        log.info("Grading with Gemini Flash: questionNumber={}", request.getQuestionNumber());
+
+        try {
+            ImageData imageData = fetchImageData(request.getSubmissionImageUrl());
+            String requestBody = buildRequestBody(request, imageData);
+
+            HttpRequest httpRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(API_URL + "?key=" + apiKey))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                    .timeout(Duration.ofSeconds(60))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() != 200) {
+                log.error("Gemini API error: status={} body={}", response.statusCode(), response.body());
+                throw new GradingProviderException(GradingProvider.GEMINI_FLASH,
+                        "HTTP " + response.statusCode() + " from Gemini API");
+            }
+
+            return parseResponse(response.body(), request);
+        } catch (ProviderNotConfiguredException | GradingProviderException e) {
+            throw e;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Gemini API call interrupted for questionNumber={}", request.getQuestionNumber(), e);
+            throw new GradingProviderException(GradingProvider.GEMINI_FLASH, e.getMessage());
+        } catch (Exception e) {
+            log.error("Gemini API call failed for questionNumber={}: {}", request.getQuestionNumber(), e.getMessage(), e);
+            throw new GradingProviderException(GradingProvider.GEMINI_FLASH, e.getMessage());
+        }
+    }
+
+    private String buildRequestBody(GradingRequest request, ImageData imageData) throws Exception {
+        var parts = new java.util.ArrayList<Object>();
+        parts.add(java.util.Map.of("text", buildGradingPrompt(request)));
+        parts.add(java.util.Map.of(
+                "inlineData", java.util.Map.of(
+                        "mimeType", imageData.mimeType(),
+                        "data", imageData.base64()
+                )
+        ));
+
+        if (request.getExpectedAnswerImageUrl() != null && !request.getExpectedAnswerImageUrl().isBlank()) {
+            parts.add(java.util.Map.of("text",
+                    "A teacher-provided model answer image is attached next. Use it as rubric context."));
+            ImageData answerImage = fetchImageData(request.getExpectedAnswerImageUrl());
+            parts.add(java.util.Map.of(
+                    "inlineData", java.util.Map.of(
+                            "mimeType", answerImage.mimeType(),
+                            "data", answerImage.base64()
+                    )
+            ));
+        }
+
+        var body = java.util.Map.of(
+                "system_instruction", java.util.Map.of(
+                        "parts", java.util.List.of(java.util.Map.of("text", buildSystemPrompt()))
+                ),
+                "contents", java.util.List.of(
+                        java.util.Map.of("parts", parts)
+                ),
+                "generationConfig", java.util.Map.of(
+                        "responseMimeType", "application/json",
+                        "temperature", 0.2,
+                        "maxOutputTokens", 1000
+                )
+        );
+
+        return objectMapper.writeValueAsString(body);
+    }
+
+    private GradingResponse parseResponse(String responseBody, GradingRequest request) {
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+            String text = root
+                    .path("candidates").get(0)
+                    .path("content")
+                    .path("parts").get(0)
+                    .path("text").asText();
+
+            JsonNode node = objectMapper.readTree(text);
+            boolean illegible = node.has("illegible") && node.get("illegible").booleanValue();
+
+            int promptTokens = root.path("usageMetadata").path("promptTokenCount").asInt(0);
+            int completionTokens = root.path("usageMetadata").path("candidatesTokenCount").asInt(0);
+
+            return GradingResponse.builder()
+                    .questionNumber(request.getQuestionNumber())
+                    .pointsAwarded(node.get("pointsAwarded").decimalValue())
+                    .pointsAvailable(request.getPointsAvailable())
+                    .confidenceScore(node.get("confidenceScore").doubleValue())
+                    .feedback(node.get("feedback").asText())
+                    .illegible(illegible)
+                    .promptTokensUsed(promptTokens)
+                    .completionTokensUsed(completionTokens)
+                    .build();
+        } catch (Exception e) {
+            log.error("Failed to parse Gemini grading response: {}", responseBody, e);
+            throw new GradingProviderException(GradingProvider.GEMINI_FLASH, "Failed to parse response: " + e.getMessage());
+        }
+    }
+
+    private String buildSystemPrompt() {
+        return """
+                You are an expert grader. Analyze handwritten student answers in images.
+                Respond in strict JSON format with these exact fields:
+                pointsAwarded (number), feedback (string),
+                confidenceScore (number between 0.0 and 1.0), illegible (boolean).
+                If the handwriting cannot be read, set illegible=true and pointsAwarded=0.
+                """;
+    }
+
+    private String buildGradingPrompt(GradingRequest req) {
+        return String.format(
+                """
+                Grade the handwritten answer in the image for question %d.
+                Expected answer: %s
+                Teacher model answer image attached: %s
+                Acceptable variations: %s
+                Grading notes: %s
+                Points available: %s
+                Respond with JSON only.
+                """,
+                req.getQuestionNumber(),
+                req.getExpectedAnswer(),
+                req.getExpectedAnswerImageUrl() != null && !req.getExpectedAnswerImageUrl().isBlank() ? "yes" : "no",
+                req.getAcceptableVariations() != null ? req.getAcceptableVariations() : "none specified",
+                req.getGradingNotes() != null ? req.getGradingNotes() : "none",
+                req.getPointsAvailable());
+    }
+
+    private ImageData fetchImageData(String url) throws IOException, InterruptedException {
+        if (url.startsWith("data:")) {
+            return parseDataUri(url);
+        }
+
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .GET()
+                .timeout(Duration.ofSeconds(30))
+                .build();
+
+        HttpResponse<byte[]> response = httpClient.send(req, HttpResponse.BodyHandlers.ofByteArray());
+        if (response.statusCode() != 200) {
+            throw new IOException("Failed to fetch image: HTTP " + response.statusCode());
+        }
+
+        String contentType = response.headers().firstValue("Content-Type").orElse("image/png");
+        String mimeType = contentType.split(";")[0].trim();
+        String base64 = Base64.getEncoder().encodeToString(response.body());
+        return new ImageData(mimeType, base64);
+    }
+
+    private ImageData parseDataUri(String dataUri) {
+        int commaIndex = dataUri.indexOf(',');
+        if (commaIndex < 0) {
+            return new ImageData("image/png", dataUri);
+        }
+        String header = dataUri.substring(5, commaIndex);
+        String base64 = dataUri.substring(commaIndex + 1);
+        String mimeType = header.contains(";") ? header.substring(0, header.indexOf(';')) : header;
+        return new ImageData(mimeType, base64);
+    }
+
+    private record ImageData(String mimeType, String base64) {}
+}

--- a/packages/backend/src/main/java/com/tracegrade/grading/GradingProvider.java
+++ b/packages/backend/src/main/java/com/tracegrade/grading/GradingProvider.java
@@ -1,0 +1,8 @@
+package com.tracegrade.grading;
+
+public enum GradingProvider {
+
+    GEMINI_FLASH,
+    OPENAI_GPT4O,
+    CLAUDE_SONNET
+}

--- a/packages/backend/src/main/java/com/tracegrade/grading/GradingProviderException.java
+++ b/packages/backend/src/main/java/com/tracegrade/grading/GradingProviderException.java
@@ -1,0 +1,18 @@
+package com.tracegrade.grading;
+
+/**
+ * Thrown when an AI grading provider call fails.
+ */
+public class GradingProviderException extends RuntimeException {
+
+    private final GradingProvider provider;
+
+    public GradingProviderException(GradingProvider provider, String message) {
+        super("[" + provider.name() + "] " + message);
+        this.provider = provider;
+    }
+
+    public GradingProvider getProvider() {
+        return provider;
+    }
+}

--- a/packages/backend/src/main/java/com/tracegrade/grading/GradingProviderRouter.java
+++ b/packages/backend/src/main/java/com/tracegrade/grading/GradingProviderRouter.java
@@ -1,0 +1,54 @@
+package com.tracegrade.grading;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.tracegrade.domain.model.User;
+import com.tracegrade.domain.model.UserRole;
+import com.tracegrade.domain.repository.UserRepository;
+import com.tracegrade.openai.OpenAiService;
+import com.tracegrade.openai.dto.GradingRequest;
+import com.tracegrade.openai.dto.GradingResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Routes grading requests to the provider saved on the teacher record.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GradingProviderRouter {
+
+    private final OpenAiService openAiService;
+    private final GeminiGradingService geminiGradingService;
+    private final ClaudeSonnetGradingService claudeSonnetGradingService;
+    private final UserRepository userRepository;
+
+    public GradingResponse gradeSubmission(UUID teacherId, GradingRequest request) {
+        GradingProvider provider = resolveProvider(teacherId);
+        log.debug("Routing grading for questionNumber={} to provider={} (teacherId={})",
+                request.getQuestionNumber(), provider, teacherId);
+
+        return switch (provider) {
+            case GEMINI_FLASH -> geminiGradingService.gradeSubmission(request);
+            case OPENAI_GPT4O -> openAiService.gradeSubmission(request);
+            case CLAUDE_SONNET -> claudeSonnetGradingService.gradeSubmission(request);
+        };
+    }
+
+    private GradingProvider resolveProvider(UUID teacherId) {
+        if (teacherId == null) {
+            return GradingProvider.GEMINI_FLASH;
+        }
+
+        return userRepository.findByIdAndRoleAndIsActiveTrue(teacherId, UserRole.TEACHER)
+                .map(User::getGradingProvider)
+                .orElseGet(() -> {
+                    log.warn("Teacher not found for teacherId={} while resolving grading provider; defaulting to GEMINI_FLASH", teacherId);
+                    return GradingProvider.GEMINI_FLASH;
+                });
+    }
+}

--- a/packages/backend/src/main/java/com/tracegrade/grading/GradingServiceImpl.java
+++ b/packages/backend/src/main/java/com/tracegrade/grading/GradingServiceImpl.java
@@ -32,7 +32,6 @@ import com.tracegrade.dto.request.GradingReviewRequest;
 import com.tracegrade.dto.response.GradingEnqueuedResponse;
 import com.tracegrade.dto.response.GradingResultResponse;
 import com.tracegrade.exception.ResourceNotFoundException;
-import com.tracegrade.openai.OpenAiService;
 import com.tracegrade.openai.dto.GradingRequest;
 import com.tracegrade.openai.dto.GradingResponse;
 import com.tracegrade.openai.exception.OpenAiException;
@@ -54,7 +53,7 @@ public class GradingServiceImpl implements GradingService {
     private final GradingResultRepository gradingResultRepository;
     private final AnswerRubricRepository rubricRepository;
     private final UserRepository userRepository;
-    private final OpenAiService openAiService;
+    private final GradingProviderRouter gradingProviderRouter;
     private final GradingProperties gradingProperties;
     private final ObjectMapper objectMapper;
     private final AuditLogService auditLogService;
@@ -184,6 +183,10 @@ public class GradingServiceImpl implements GradingService {
         submission.setStatus(SubmissionStatus.PROCESSING);
         submissionRepository.save(submission);
 
+        UUID teacherId = submission.getExamTemplate() != null
+            ? submission.getExamTemplate().getTeacherId()
+            : null;
+
         long startMs = System.currentTimeMillis();
         List<GradingResponse> aiResponses = new ArrayList<>();
 
@@ -203,11 +206,11 @@ public class GradingServiceImpl implements GradingService {
                     .build();
 
             try {
-                aiResponses.add(openAiService.gradeSubmission(req));
+                aiResponses.add(gradingProviderRouter.gradeSubmission(teacherId, req));
                 if (gradingMetricsService != null) {
                     gradingMetricsService.recordOpenAiSuccess();
                 }
-            } catch (OpenAiException ex) {
+            } catch (ProviderNotConfiguredException | GradingProviderException | OpenAiException ex) {
                 log.error("AI grading failed for submissionId={} questionNumber={}: {}",
                         submissionId, rubric.getQuestionNumber(), ex.getMessage(), ex);
                 if (gradingMetricsService != null) {

--- a/packages/backend/src/main/java/com/tracegrade/grading/ProviderNotConfiguredException.java
+++ b/packages/backend/src/main/java/com/tracegrade/grading/ProviderNotConfiguredException.java
@@ -1,0 +1,18 @@
+package com.tracegrade.grading;
+
+/**
+ * Thrown when a teacher selects a grading provider whose API key is not configured.
+ */
+public class ProviderNotConfiguredException extends RuntimeException {
+
+    private final GradingProvider provider;
+
+    public ProviderNotConfiguredException(GradingProvider provider) {
+        super("Grading provider " + provider.name() + " is not configured - missing API key");
+        this.provider = provider;
+    }
+
+    public GradingProvider getProvider() {
+        return provider;
+    }
+}

--- a/packages/backend/src/main/java/com/tracegrade/settings/GradingProviderController.java
+++ b/packages/backend/src/main/java/com/tracegrade/settings/GradingProviderController.java
@@ -1,0 +1,67 @@
+package com.tracegrade.settings;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.tracegrade.dto.response.ApiResponse;
+import com.tracegrade.settings.dto.request.UpdateGradingProviderRequest;
+import com.tracegrade.settings.dto.response.GradingProviderResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/settings/grading")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "Grading Settings", description = "Teacher AI grading provider selection")
+@SecurityRequirement(name = "BearerAuth")
+public class GradingProviderController {
+
+    private final GradingProviderService gradingProviderService;
+
+    @Operation(
+            summary = "Get current teacher grading provider",
+            description = "Returns the teacher's selected AI grading provider and all available options."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Grading provider returned"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Authentication required", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Access denied", content = @Content)
+    })
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<GradingProviderResponse>> getCurrentProvider(Authentication authentication) {
+        GradingProviderResponse response = gradingProviderService.getCurrentProvider(authentication);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(
+            summary = "Update teacher grading provider",
+            description = "Updates the AI provider used to grade this teacher's exam submissions. Returns PROVIDER_NOT_CONFIGURED error if the selected provider's API key is not set."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Grading provider updated"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid or unconfigured provider", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Authentication required", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Access denied", content = @Content)
+    })
+    @PatchMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<GradingProviderResponse>> updateProvider(
+            Authentication authentication,
+            @Valid @RequestBody UpdateGradingProviderRequest request) {
+        GradingProviderResponse response = gradingProviderService.updateProvider(authentication, request.getProvider());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/packages/backend/src/main/java/com/tracegrade/settings/GradingProviderService.java
+++ b/packages/backend/src/main/java/com/tracegrade/settings/GradingProviderService.java
@@ -1,0 +1,122 @@
+package com.tracegrade.settings;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.tracegrade.domain.model.User;
+import com.tracegrade.domain.model.UserRole;
+import com.tracegrade.domain.repository.UserRepository;
+import com.tracegrade.exception.ResourceNotFoundException;
+import com.tracegrade.grading.GradingProvider;
+import com.tracegrade.settings.dto.response.GradingProviderResponse;
+import com.tracegrade.settings.dto.response.GradingProviderResponse.ProviderOption;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GradingProviderService {
+
+    private static final List<ProviderOption> AVAILABLE_PROVIDERS = List.of(
+            ProviderOption.builder()
+                    .id(GradingProvider.GEMINI_FLASH)
+                    .displayName("Gemini 2.0 Flash")
+                    .description("Free - recommended")
+                    .build(),
+            ProviderOption.builder()
+                    .id(GradingProvider.OPENAI_GPT4O)
+                    .displayName("GPT-4o")
+                    .description("OpenAI - requires API key")
+                    .build(),
+            ProviderOption.builder()
+                    .id(GradingProvider.CLAUDE_SONNET)
+                    .displayName("Claude Sonnet 4.6")
+                    .description("Anthropic - requires API key")
+                    .build()
+    );
+
+    private final UserRepository userRepository;
+
+    @Value("${GEMINI_API_KEY:}")
+    private String geminiApiKey;
+
+    @Value("${OPENAI_API_KEY:}")
+    private String openAiApiKey;
+
+    @Value("${ANTHROPIC_API_KEY:}")
+    private String anthropicApiKey;
+
+    @Transactional(readOnly = true)
+    public GradingProviderResponse getCurrentProvider(Authentication authentication) {
+        User teacher = getAuthenticatedTeacher(authentication);
+        return buildResponse(teacher.getGradingProvider());
+    }
+
+    @Transactional
+    public GradingProviderResponse updateProvider(Authentication authentication, GradingProvider provider) {
+        validateProviderConfigured(provider);
+        User teacher = getAuthenticatedTeacher(authentication);
+        teacher.setGradingProvider(provider);
+        userRepository.save(teacher);
+        log.info("Teacher {} updated grading provider to {}", teacher.getId(), provider);
+        return buildResponse(provider);
+    }
+
+    private void validateProviderConfigured(GradingProvider provider) {
+        boolean configured = switch (provider) {
+            case GEMINI_FLASH -> geminiApiKey != null && !geminiApiKey.isBlank();
+            case OPENAI_GPT4O -> openAiApiKey != null && !openAiApiKey.isBlank();
+            case CLAUDE_SONNET -> anthropicApiKey != null && !anthropicApiKey.isBlank();
+        };
+
+        if (!configured) {
+            log.warn("Teacher attempted to select provider {} but corresponding API key is not configured", provider);
+            throw new ProviderNotConfiguredApiException(provider);
+        }
+    }
+
+    private GradingProviderResponse buildResponse(GradingProvider current) {
+        return GradingProviderResponse.builder()
+                .currentProvider(current)
+                .availableProviders(AVAILABLE_PROVIDERS)
+                .build();
+    }
+
+    private User getAuthenticatedTeacher(Authentication authentication) {
+        UUID teacherId = resolveTeacherId(authentication);
+        return userRepository.findByIdAndRoleAndIsActiveTrue(teacherId, UserRole.TEACHER)
+                .orElseThrow(() -> new ResourceNotFoundException("User", teacherId));
+    }
+
+    private UUID resolveTeacherId(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new AccessDeniedException("Authentication is required");
+        }
+        try {
+            return UUID.fromString(authentication.getName());
+        } catch (IllegalArgumentException e) {
+            throw new AccessDeniedException("Authenticated principal does not contain a valid teacher identifier");
+        }
+    }
+
+    public static class ProviderNotConfiguredApiException extends RuntimeException {
+        private final GradingProvider provider;
+
+        public ProviderNotConfiguredApiException(GradingProvider provider) {
+            super("PROVIDER_NOT_CONFIGURED: " + provider.name() + " requires an API key that is not set");
+            this.provider = provider;
+        }
+
+        public GradingProvider getProvider() {
+            return provider;
+        }
+    }
+}

--- a/packages/backend/src/main/java/com/tracegrade/settings/dto/request/UpdateGradingProviderRequest.java
+++ b/packages/backend/src/main/java/com/tracegrade/settings/dto/request/UpdateGradingProviderRequest.java
@@ -1,0 +1,13 @@
+package com.tracegrade.settings.dto.request;
+
+import com.tracegrade.grading.GradingProvider;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class UpdateGradingProviderRequest {
+
+    @NotNull(message = "provider must not be null")
+    private GradingProvider provider;
+}

--- a/packages/backend/src/main/java/com/tracegrade/settings/dto/response/GradingProviderResponse.java
+++ b/packages/backend/src/main/java/com/tracegrade/settings/dto/response/GradingProviderResponse.java
@@ -1,0 +1,24 @@
+package com.tracegrade.settings.dto.response;
+
+import java.util.List;
+
+import com.tracegrade.grading.GradingProvider;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class GradingProviderResponse {
+
+    private GradingProvider currentProvider;
+    private List<ProviderOption> availableProviders;
+
+    @Data
+    @Builder
+    public static class ProviderOption {
+        private GradingProvider id;
+        private String displayName;
+        private String description;
+    }
+}

--- a/packages/backend/src/main/resources/db/migration/V16__add_grading_provider_to_users.sql
+++ b/packages/backend/src/main/resources/db/migration/V16__add_grading_provider_to_users.sql
@@ -1,0 +1,9 @@
+-- FEAT: per-teacher AI grading provider selection
+-- Adds grading_provider column to users table; defaults to GEMINI_FLASH
+
+ALTER TABLE users
+    ADD COLUMN grading_provider VARCHAR(50) NOT NULL DEFAULT 'GEMINI_FLASH';
+
+ALTER TABLE users
+    ADD CONSTRAINT chk_users_grading_provider
+        CHECK (grading_provider IN ('GEMINI_FLASH', 'OPENAI_GPT4O', 'CLAUDE_SONNET'));

--- a/packages/backend/src/test/java/com/tracegrade/grading/GradingProviderRouterTest.java
+++ b/packages/backend/src/test/java/com/tracegrade/grading/GradingProviderRouterTest.java
@@ -1,0 +1,110 @@
+package com.tracegrade.grading;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.tracegrade.domain.model.User;
+import com.tracegrade.domain.model.UserRole;
+import com.tracegrade.domain.repository.UserRepository;
+import com.tracegrade.openai.OpenAiService;
+import com.tracegrade.openai.dto.GradingRequest;
+import com.tracegrade.openai.dto.GradingResponse;
+
+@SuppressWarnings("null")
+class GradingProviderRouterTest {
+
+    private OpenAiService openAiService;
+    private GeminiGradingService geminiGradingService;
+    private ClaudeSonnetGradingService claudeSonnetGradingService;
+    private UserRepository userRepository;
+    private GradingProviderRouter router;
+
+    @BeforeEach
+    void setUp() {
+        openAiService = mock(OpenAiService.class);
+        geminiGradingService = mock(GeminiGradingService.class);
+        claudeSonnetGradingService = mock(ClaudeSonnetGradingService.class);
+        userRepository = mock(UserRepository.class);
+        router = new GradingProviderRouter(openAiService, geminiGradingService, claudeSonnetGradingService, userRepository);
+    }
+
+    @Test
+    @DisplayName("Routes grading to the teacher's configured provider")
+    void routesToConfiguredProvider() {
+        UUID teacherId = UUID.randomUUID();
+        GradingRequest request = request();
+        GradingResponse expected = response(1, 0.88);
+        User teacher = User.builder()
+                .email("teacher@test.com")
+                .passwordHash("hash")
+                .firstName("Ada")
+                .lastName("Teacher")
+                .role(UserRole.TEACHER)
+                .isActive(true)
+                .build();
+        teacher.setId(teacherId);
+        teacher.setGradingProvider(GradingProvider.OPENAI_GPT4O);
+
+        when(userRepository.findByIdAndRoleAndIsActiveTrue(teacherId, UserRole.TEACHER)).thenReturn(Optional.of(teacher));
+        when(openAiService.gradeSubmission(request)).thenReturn(expected);
+
+        GradingResponse actual = router.gradeSubmission(teacherId, request);
+
+        assertThat(actual).isSameAs(expected);
+        verify(openAiService).gradeSubmission(request);
+        verify(geminiGradingService, never()).gradeSubmission(any());
+        verify(claudeSonnetGradingService, never()).gradeSubmission(any());
+    }
+
+    @Test
+    @DisplayName("Defaults to Gemini when the teacher cannot be resolved")
+    void defaultsToGeminiWhenTeacherMissing() {
+        UUID teacherId = UUID.randomUUID();
+        GradingRequest request = request();
+        GradingResponse expected = response(1, 0.91);
+
+        when(userRepository.findByIdAndRoleAndIsActiveTrue(eq(teacherId), eq(UserRole.TEACHER)))
+                .thenReturn(Optional.empty());
+        when(geminiGradingService.gradeSubmission(request)).thenReturn(expected);
+
+        GradingResponse actual = router.gradeSubmission(teacherId, request);
+
+        assertThat(actual).isSameAs(expected);
+        verify(geminiGradingService).gradeSubmission(request);
+        verify(openAiService, never()).gradeSubmission(any());
+        verify(claudeSonnetGradingService, never()).gradeSubmission(any());
+    }
+
+    private static GradingRequest request() {
+        return GradingRequest.builder()
+                .submissionImageUrl("https://example.com/submission.jpg")
+                .questionNumber(1)
+                .expectedAnswer("42")
+                .pointsAvailable(new BigDecimal("5.00"))
+                .build();
+    }
+
+    private static GradingResponse response(int questionNumber, double confidenceScore) {
+        return GradingResponse.builder()
+                .questionNumber(questionNumber)
+                .pointsAwarded(new BigDecimal("4.50"))
+                .pointsAvailable(new BigDecimal("5.00"))
+                .confidenceScore(confidenceScore)
+                .feedback("Good work")
+                .illegible(false)
+                .build();
+    }
+}

--- a/packages/backend/src/test/java/com/tracegrade/grading/GradingServiceImplTest.java
+++ b/packages/backend/src/test/java/com/tracegrade/grading/GradingServiceImplTest.java
@@ -37,7 +37,6 @@ import com.tracegrade.domain.repository.StudentSubmissionRepository;
 import com.tracegrade.domain.repository.UserRepository;
 import com.tracegrade.dto.response.GradingResultResponse;
 import com.tracegrade.exception.ResourceNotFoundException;
-import com.tracegrade.openai.OpenAiService;
 import com.tracegrade.openai.dto.GradingRequest;
 import com.tracegrade.openai.dto.GradingResponse;
 import com.tracegrade.openai.exception.OpenAiException;
@@ -55,7 +54,7 @@ class GradingServiceImplTest {
     private GradingResultRepository     gradingResultRepository;
     private AnswerRubricRepository      rubricRepository;
         private UserRepository              userRepository;
-    private OpenAiService               openAiService;
+        private GradingProviderRouter       gradingProviderRouter;
     private GradingProperties           gradingProperties;
     private AuditLogService             auditLogService;
     private GradingServiceImpl          service;
@@ -71,13 +70,13 @@ class GradingServiceImplTest {
         gradingResultRepository = mock(GradingResultRepository.class);
         rubricRepository        = mock(AnswerRubricRepository.class);
         userRepository          = mock(UserRepository.class);
-        openAiService           = mock(OpenAiService.class);
+        gradingProviderRouter   = mock(GradingProviderRouter.class);
         gradingProperties       = new GradingProperties();
         gradingProperties.setConfidenceThreshold(0.80);
         auditLogService         = mock(AuditLogService.class);
         service = new GradingServiceImpl(
                 submissionRepository, gradingResultRepository,
-                rubricRepository, userRepository, openAiService,
+                rubricRepository, userRepository, gradingProviderRouter,
                 gradingProperties, new ObjectMapper(), auditLogService
         );
     }
@@ -199,7 +198,7 @@ class GradingServiceImplTest {
             GradingResultResponse response = service.grade(SUBMISSION_ID);
 
             assertThat(response.getGradeId()).isEqualTo(existing.getGradeId());
-            verify(openAiService, never()).gradeSubmission(any());
+            verify(gradingProviderRouter, never()).gradeSubmission(any(), any());
             verify(submissionRepository, never()).save(any());
         }
 
@@ -259,7 +258,7 @@ class GradingServiceImplTest {
             when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
             when(rubricRepository.findByExamTemplateIdOrderByQuestionNumberAsc(TEMPLATE_ID))
                     .thenReturn(List.of(rubric));
-            when(openAiService.gradeSubmission(any())).thenReturn(aiResp);
+            when(gradingProviderRouter.gradeSubmission(any(), any())).thenReturn(aiResp);
             stubSubmissionSave(submission);
             stubResultSave();
 
@@ -282,7 +281,7 @@ class GradingServiceImplTest {
             when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
             when(rubricRepository.findByExamTemplateIdOrderByQuestionNumberAsc(TEMPLATE_ID))
                     .thenReturn(List.of(rubric));
-            when(openAiService.gradeSubmission(any())).thenReturn(aiResp);
+            when(gradingProviderRouter.gradeSubmission(any(), any())).thenReturn(aiResp);
             stubSubmissionSave(submission);
             stubResultSave();
 
@@ -304,7 +303,7 @@ class GradingServiceImplTest {
             when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
             when(rubricRepository.findByExamTemplateIdOrderByQuestionNumberAsc(TEMPLATE_ID))
                     .thenReturn(List.of(rubric));
-            when(openAiService.gradeSubmission(any())).thenReturn(aiResp);
+            when(gradingProviderRouter.gradeSubmission(any(), any())).thenReturn(aiResp);
             stubSubmissionSave(submission);
             stubResultSave();
 
@@ -340,7 +339,7 @@ class GradingServiceImplTest {
                     .thenReturn(List.of(rubric));
             when(userRepository.findByIdAndRoleAndIsActiveTrue(teacherId, UserRole.TEACHER))
                     .thenReturn(Optional.of(teacher));
-            when(openAiService.gradeSubmission(any())).thenReturn(aiResp);
+            when(gradingProviderRouter.gradeSubmission(any(), any())).thenReturn(aiResp);
             stubSubmissionSave(submission);
             stubResultSave();
 
@@ -365,7 +364,7 @@ class GradingServiceImplTest {
                     .thenReturn(List.of(rubric));
             when(userRepository.findByIdAndRoleAndIsActiveTrue(teacherId, UserRole.TEACHER))
                     .thenReturn(Optional.empty());
-            when(openAiService.gradeSubmission(any())).thenReturn(aiResp);
+            when(gradingProviderRouter.gradeSubmission(any(), any())).thenReturn(aiResp);
             stubSubmissionSave(submission);
             stubResultSave();
 
@@ -386,7 +385,7 @@ class GradingServiceImplTest {
             when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
             when(rubricRepository.findByExamTemplateIdOrderByQuestionNumberAsc(TEMPLATE_ID))
                     .thenReturn(List.of(rubric));
-            when(openAiService.gradeSubmission(any())).thenReturn(aiResp);
+            when(gradingProviderRouter.gradeSubmission(any(), any())).thenReturn(aiResp);
             stubSubmissionSave(submission);
             stubResultSave();
 
@@ -419,7 +418,7 @@ class GradingServiceImplTest {
             when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
             when(rubricRepository.findByExamTemplateIdOrderByQuestionNumberAsc(TEMPLATE_ID))
                     .thenReturn(List.of(rubric1, rubric2));
-            when(openAiService.gradeSubmission(any()))
+            when(gradingProviderRouter.gradeSubmission(any(), any()))
                     .thenReturn(aiResp1)
                     .thenReturn(aiResp2);
             stubSubmissionSave(submission);
@@ -442,7 +441,7 @@ class GradingServiceImplTest {
             when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
             when(rubricRepository.findByExamTemplateIdOrderByQuestionNumberAsc(TEMPLATE_ID))
                     .thenReturn(List.of(rubric));
-            when(openAiService.gradeSubmission(any()))
+            when(gradingProviderRouter.gradeSubmission(any(), any()))
                     .thenThrow(new OpenAiException("GRADING", "API error", 500));
             stubSubmissionSave(submission);
             stubResultSave();
@@ -472,7 +471,7 @@ class GradingServiceImplTest {
             when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
             when(rubricRepository.findByExamTemplateIdOrderByQuestionNumberAsc(TEMPLATE_ID))
                     .thenReturn(List.of(rubric));
-            when(openAiService.gradeSubmission(any()))
+            when(gradingProviderRouter.gradeSubmission(any(), any()))
                     .thenThrow(new OpenAiRateLimitException("GRADING", 4));
             stubSubmissionSave(submission);
             stubResultSave();
@@ -499,7 +498,7 @@ class GradingServiceImplTest {
             when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
             when(rubricRepository.findByExamTemplateIdOrderByQuestionNumberAsc(TEMPLATE_ID))
                     .thenReturn(List.of(rubric1, rubric2));
-            when(openAiService.gradeSubmission(any(GradingRequest.class)))
+            when(gradingProviderRouter.gradeSubmission(any(), any(GradingRequest.class)))
                     .thenReturn(buildAiResponse(1, 0.90, false))
                     .thenThrow(new OpenAiException("GRADING", "API error", 500));
             stubSubmissionSave(submission);
@@ -522,7 +521,7 @@ class GradingServiceImplTest {
             when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
             when(rubricRepository.findByExamTemplateIdOrderByQuestionNumberAsc(TEMPLATE_ID))
                     .thenReturn(List.of(rubric));
-            when(openAiService.gradeSubmission(any())).thenReturn(buildAiResponse(1, 0.90, false));
+            when(gradingProviderRouter.gradeSubmission(any(), any())).thenReturn(buildAiResponse(1, 0.90, false));
             stubSubmissionSave(submission);
             stubResultSave();
 
@@ -543,7 +542,7 @@ class GradingServiceImplTest {
             when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
             when(rubricRepository.findByExamTemplateIdOrderByQuestionNumberAsc(TEMPLATE_ID))
                     .thenReturn(List.of(rubric));
-            when(openAiService.gradeSubmission(any())).thenReturn(buildAiResponse(1, 0.90, false));
+            when(gradingProviderRouter.gradeSubmission(any(), any())).thenReturn(buildAiResponse(1, 0.90, false));
             stubSubmissionSave(submission);
             stubResultSave();
 
@@ -568,7 +567,7 @@ class GradingServiceImplTest {
             when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
             when(rubricRepository.findByExamTemplateIdOrderByQuestionNumberAsc(TEMPLATE_ID))
                     .thenReturn(List.of(rubric1, rubric2));
-            when(openAiService.gradeSubmission(any()))
+            when(gradingProviderRouter.gradeSubmission(any(), any()))
                     .thenReturn(aiResp1)
                     .thenReturn(aiResp2);
             stubSubmissionSave(submission);
@@ -696,7 +695,7 @@ class GradingServiceImplTest {
             assertThat(response.getStatus()).isEqualTo("QUEUED");
             assertThat(response.getEnqueuedAt()).isNotNull();
             verify(mockPublisher).publishGradingJob(SUBMISSION_ID);
-            verify(openAiService, never()).gradeSubmission(any());
+            verify(gradingProviderRouter, never()).gradeSubmission(any(), any());
         }
 
         @Test
@@ -754,7 +753,7 @@ class GradingServiceImplTest {
             when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
             when(rubricRepository.findByExamTemplateIdOrderByQuestionNumberAsc(TEMPLATE_ID))
                     .thenReturn(List.of(rubric));
-            when(openAiService.gradeSubmission(any())).thenReturn(aiResp);
+            when(gradingProviderRouter.gradeSubmission(any(), any())).thenReturn(aiResp);
             stubSubmissionSave(submission);
             stubResultSave();
 
@@ -763,7 +762,7 @@ class GradingServiceImplTest {
             assertThat(response.getSubmissionId()).isEqualTo(SUBMISSION_ID);
             assertThat(response.getStatus()).isEqualTo("COMPLETED");
             assertThat(response.getEnqueuedAt()).isNotNull();
-            verify(openAiService).gradeSubmission(any());
+            verify(gradingProviderRouter).gradeSubmission(any(), any());
         }
 
         @Test
@@ -779,14 +778,14 @@ class GradingServiceImplTest {
             when(submissionRepository.findById(SUBMISSION_ID)).thenReturn(Optional.of(submission));
             when(rubricRepository.findByExamTemplateIdOrderByQuestionNumberAsc(TEMPLATE_ID))
                     .thenReturn(List.of(rubric));
-            when(openAiService.gradeSubmission(any())).thenReturn(aiResp);
+            when(gradingProviderRouter.gradeSubmission(any(), any())).thenReturn(aiResp);
             stubSubmissionSave(submission);
             stubResultSave();
 
             service.grade(SUBMISSION_ID);
 
             ArgumentCaptor<GradingRequest> requestCaptor = ArgumentCaptor.forClass(GradingRequest.class);
-            verify(openAiService).gradeSubmission(requestCaptor.capture());
+            verify(gradingProviderRouter).gradeSubmission(any(), requestCaptor.capture());
             assertThat(requestCaptor.getValue().getExpectedAnswerImageUrl())
                     .isEqualTo("https://cdn.example.com/rubrics/q1.jpg");
         }

--- a/packages/backend/src/test/java/com/tracegrade/settings/GradingProviderControllerTest.java
+++ b/packages/backend/src/test/java/com/tracegrade/settings/GradingProviderControllerTest.java
@@ -1,0 +1,158 @@
+package com.tracegrade.settings;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tracegrade.exception.GlobalExceptionHandler;
+import com.tracegrade.grading.GradingProvider;
+import com.tracegrade.settings.dto.response.GradingProviderResponse;
+
+@SuppressWarnings("null")
+class GradingProviderControllerTest {
+
+    private MockMvc mockMvc;
+    private GradingProviderService gradingProviderService;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        gradingProviderService = mock(GradingProviderService.class);
+        GradingProviderController controller = new GradingProviderController(gradingProviderService);
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setValidator(validator)
+                .build();
+
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    @DisplayName("GET returns the current grading provider and available options")
+    void getCurrentProviderReturnsOk() throws Exception {
+        UUID teacherId = UUID.randomUUID();
+        GradingProviderResponse response = providerResponse(GradingProvider.GEMINI_FLASH);
+
+        when(gradingProviderService.getCurrentProvider(any(Authentication.class))).thenReturn(response);
+
+        mockMvc.perform(get("/api/settings/grading")
+                        .principal(principal(teacherId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.data.currentProvider", is("GEMINI_FLASH")))
+                .andExpect(jsonPath("$.data.availableProviders", hasSize(3)))
+                .andExpect(jsonPath("$.data.availableProviders[0].id", is("GEMINI_FLASH")))
+                .andExpect(jsonPath("$.data.availableProviders[1].id", is("OPENAI_GPT4O")))
+                .andExpect(jsonPath("$.data.availableProviders[2].id", is("CLAUDE_SONNET")));
+
+        verify(gradingProviderService).getCurrentProvider(any(Authentication.class));
+    }
+
+    @Test
+    @DisplayName("PATCH returns 200 and updates the teacher grading provider")
+    void updateProviderReturnsOk() throws Exception {
+        UUID teacherId = UUID.randomUUID();
+        GradingProviderResponse response = providerResponse(GradingProvider.CLAUDE_SONNET);
+
+        when(gradingProviderService.updateProvider(any(Authentication.class), eq(GradingProvider.CLAUDE_SONNET)))
+                .thenReturn(response);
+
+        mockMvc.perform(patch("/api/settings/grading")
+                        .principal(principal(teacherId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ProviderRequest("CLAUDE_SONNET"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.data.currentProvider", is("CLAUDE_SONNET")));
+
+        verify(gradingProviderService)
+                .updateProvider(any(Authentication.class), eq(GradingProvider.CLAUDE_SONNET));
+    }
+
+    @Test
+    @DisplayName("PATCH returns 400 when provider is null")
+    void updateProviderReturnsBadRequestForNullProvider() throws Exception {
+        UUID teacherId = UUID.randomUUID();
+
+        mockMvc.perform(patch("/api/settings/grading")
+                        .principal(principal(teacherId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"provider\":null}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.error.code", is("VALIDATION_ERROR")));
+
+        verifyNoInteractions(gradingProviderService);
+    }
+
+    @Test
+    @DisplayName("PATCH returns 400 when the selected provider is not configured")
+    void updateProviderReturnsBadRequestForUnconfiguredProvider() throws Exception {
+        UUID teacherId = UUID.randomUUID();
+
+        when(gradingProviderService.updateProvider(any(Authentication.class), eq(GradingProvider.CLAUDE_SONNET)))
+                .thenThrow(new GradingProviderService.ProviderNotConfiguredApiException(GradingProvider.CLAUDE_SONNET));
+
+        mockMvc.perform(patch("/api/settings/grading")
+                        .principal(principal(teacherId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new ProviderRequest("CLAUDE_SONNET"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.error.code", is("PROVIDER_NOT_CONFIGURED")));
+    }
+
+    private static Authentication principal(UUID teacherId) {
+        return new UsernamePasswordAuthenticationToken(teacherId.toString(), "N/A", List.of());
+    }
+
+    private static GradingProviderResponse providerResponse(GradingProvider currentProvider) {
+        return GradingProviderResponse.builder()
+                .currentProvider(currentProvider)
+                .availableProviders(List.of(
+                        GradingProviderResponse.ProviderOption.builder()
+                                .id(GradingProvider.GEMINI_FLASH)
+                                .displayName("Gemini 2.0 Flash")
+                                .description("Free — recommended")
+                                .build(),
+                        GradingProviderResponse.ProviderOption.builder()
+                                .id(GradingProvider.OPENAI_GPT4O)
+                                .displayName("GPT-4o")
+                                .description("OpenAI — requires API key")
+                                .build(),
+                        GradingProviderResponse.ProviderOption.builder()
+                                .id(GradingProvider.CLAUDE_SONNET)
+                                .displayName("Claude Sonnet 4.6")
+                                .description("Anthropic — requires API key")
+                                .build()))
+                .build();
+    }
+
+    private record ProviderRequest(String provider) {}
+}

--- a/packages/frontend/src/features/settings/settingsApi.test.ts
+++ b/packages/frontend/src/features/settings/settingsApi.test.ts
@@ -1,15 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import api from '../../lib/api'
-import { getTeacherThreshold, updateTeacherThreshold } from './settingsApi'
+import { getGradingProvider, getTeacherThreshold, updateGradingProvider, updateTeacherThreshold } from './settingsApi'
 
 vi.mock('../../lib/api', () => ({
   default: {
     get: vi.fn(),
+    patch: vi.fn(),
     put: vi.fn(),
   },
 }))
 
 const mockedGet = vi.mocked(api.get)
+const mockedPatch = vi.mocked(api.patch)
 const mockedPut = vi.mocked(api.put)
 
 describe('settingsApi normalization', () => {
@@ -160,6 +162,157 @@ describe('settingsApi normalization', () => {
         },
       })
       await expect(updateTeacherThreshold(0.8)).rejects.toThrow('Unexpected response while saving threshold')
+    })
+  })
+
+  describe('getGradingProvider', () => {
+    it('normalizes the current provider and available options', async () => {
+      mockedGet.mockResolvedValueOnce({
+        data: {
+          data: {
+            currentProvider: 'GEMINI_FLASH',
+            availableProviders: [
+              {
+                id: 'GEMINI_FLASH',
+                displayName: 'Gemini 2.0 Flash',
+                description: 'Free — recommended',
+              },
+              {
+                id: 'OPENAI_GPT4O',
+                displayName: 'GPT-4o',
+                description: 'OpenAI — requires API key',
+              },
+            ],
+          },
+        },
+      })
+
+      await expect(getGradingProvider()).resolves.toEqual({
+        currentProvider: 'GEMINI_FLASH',
+        availableProviders: [
+          {
+            id: 'GEMINI_FLASH',
+            displayName: 'Gemini 2.0 Flash',
+            description: 'Free — recommended',
+          },
+          {
+            id: 'OPENAI_GPT4O',
+            displayName: 'GPT-4o',
+            description: 'OpenAI — requires API key',
+          },
+        ],
+      })
+      expect(mockedGet).toHaveBeenCalledWith('/settings/grading')
+    })
+
+    it('returns null when the provider payload is malformed', async () => {
+      mockedGet.mockResolvedValueOnce({ data: { data: undefined } })
+      await expect(getGradingProvider()).resolves.toBeNull()
+
+      mockedGet.mockResolvedValueOnce({
+        data: {
+          data: {
+            currentProvider: 'NOPE',
+            availableProviders: [],
+          },
+        },
+      })
+      await expect(getGradingProvider()).resolves.toBeNull()
+
+      mockedGet.mockResolvedValueOnce({
+        data: {
+          data: {
+            currentProvider: 'GEMINI_FLASH',
+            availableProviders: [
+              {
+                id: 'CLAUDE_SONNET',
+                displayName: 'Claude Sonnet 4.6',
+                description: 42,
+              },
+            ],
+          },
+        },
+      })
+      await expect(getGradingProvider()).resolves.toBeNull()
+    })
+  })
+
+  describe('updateGradingProvider', () => {
+    it('normalizes the saved provider response', async () => {
+      mockedPatch.mockResolvedValueOnce({
+        data: {
+          data: {
+            currentProvider: 'CLAUDE_SONNET',
+            availableProviders: [
+              {
+                id: 'GEMINI_FLASH',
+                displayName: 'Gemini 2.0 Flash',
+                description: 'Free — recommended',
+              },
+              {
+                id: 'CLAUDE_SONNET',
+                displayName: 'Claude Sonnet 4.6',
+                description: 'Anthropic — requires API key',
+              },
+            ],
+          },
+        },
+      })
+
+      await expect(updateGradingProvider('CLAUDE_SONNET')).resolves.toEqual({
+        currentProvider: 'CLAUDE_SONNET',
+        availableProviders: [
+          {
+            id: 'GEMINI_FLASH',
+            displayName: 'Gemini 2.0 Flash',
+            description: 'Free — recommended',
+          },
+          {
+            id: 'CLAUDE_SONNET',
+            displayName: 'Claude Sonnet 4.6',
+            description: 'Anthropic — requires API key',
+          },
+        ],
+      })
+      expect(mockedPatch).toHaveBeenCalledWith('/settings/grading', {
+        provider: 'CLAUDE_SONNET',
+      })
+    })
+
+    it('throws when the saved provider payload is malformed', async () => {
+      mockedPatch.mockResolvedValueOnce({ data: { data: undefined } })
+      await expect(updateGradingProvider('OPENAI_GPT4O')).rejects.toThrow('Unexpected response while saving grading provider')
+
+      mockedPatch.mockResolvedValueOnce({
+        data: {
+          data: {
+            currentProvider: 'OPENAI_GPT4O',
+            availableProviders: [
+              {
+                id: 'INVALID',
+                displayName: 'Broken',
+                description: 'Broken',
+              },
+            ],
+          },
+        },
+      })
+      await expect(updateGradingProvider('OPENAI_GPT4O')).rejects.toThrow('Unexpected response while saving grading provider')
+    })
+
+    it('rethrows the backend provider code when the selected model is not configured', async () => {
+      mockedPatch.mockRejectedValueOnce({
+        isAxiosError: true,
+        response: {
+          data: {
+            error: {
+              code: 'PROVIDER_NOT_CONFIGURED',
+            },
+          },
+        },
+      })
+
+      await expect(updateGradingProvider('CLAUDE_SONNET')).rejects.toThrow('PROVIDER_NOT_CONFIGURED')
     })
   })
 })

--- a/packages/frontend/src/features/settings/settingsApi.ts
+++ b/packages/frontend/src/features/settings/settingsApi.ts
@@ -1,6 +1,7 @@
+import axios from 'axios'
 import api from '../../lib/api'
 import type { ApiResponse } from '../../lib/apiTypes'
-import type { TeacherThreshold, ThresholdSource } from './types'
+import type { GradingProviderSettings, GradingProviderId, ProviderOption, TeacherThreshold, ThresholdSource } from './types'
 
 interface TeacherThresholdPayload {
   effectiveThreshold?: unknown
@@ -73,4 +74,67 @@ export async function updateTeacherThreshold(threshold: number): Promise<Teacher
   }
 
   return normalized
+}
+
+// ---------------------------------------------------------------------------
+// Grading provider
+// ---------------------------------------------------------------------------
+
+const VALID_PROVIDER_IDS: GradingProviderId[] = ['GEMINI_FLASH', 'OPENAI_GPT4O', 'CLAUDE_SONNET']
+
+function isValidProviderId(value: unknown): value is GradingProviderId {
+  return typeof value === 'string' && (VALID_PROVIDER_IDS as string[]).includes(value)
+}
+
+function normalizeProviderOption(raw: unknown): ProviderOption | null {
+  if (!raw || typeof raw !== 'object') return null
+  const obj = raw as Record<string, unknown>
+  if (!isValidProviderId(obj.id) || typeof obj.displayName !== 'string' || typeof obj.description !== 'string') {
+    return null
+  }
+  return { id: obj.id, displayName: obj.displayName, description: obj.description }
+}
+
+function normalizeGradingProviderResponse(payload: unknown): GradingProviderSettings | null {
+  if (!payload || typeof payload !== 'object') return null
+  const obj = payload as Record<string, unknown>
+  if (!isValidProviderId(obj.currentProvider)) return null
+  if (!Array.isArray(obj.availableProviders)) return null
+  const options = obj.availableProviders.map(normalizeProviderOption)
+  if (options.some((o) => o === null)) return null
+  return {
+    currentProvider: obj.currentProvider,
+    availableProviders: options as ProviderOption[],
+  }
+}
+
+function getApiErrorCode(error: unknown): string | null {
+  if (!axios.isAxiosError(error)) {
+    return null
+  }
+
+  const code = (error.response?.data as { error?: { code?: unknown } } | undefined)?.error?.code
+  return typeof code === 'string' ? code : null
+}
+
+export async function getGradingProvider(): Promise<GradingProviderSettings | null> {
+  const response = await api.get<ApiResponse<unknown>>('/settings/grading')
+  return normalizeGradingProviderResponse(response.data?.data)
+}
+
+export async function updateGradingProvider(provider: GradingProviderId): Promise<GradingProviderSettings> {
+  try {
+    const response = await api.patch<ApiResponse<unknown>>('/settings/grading', { provider })
+    const normalized = normalizeGradingProviderResponse(response.data?.data)
+    if (!normalized) {
+      throw new Error('Unexpected response while saving grading provider')
+    }
+    return normalized
+  } catch (error) {
+    const errorCode = getApiErrorCode(error)
+    if (errorCode) {
+      throw new Error(errorCode)
+    }
+    throw error
+  }
 }

--- a/packages/frontend/src/features/settings/types.ts
+++ b/packages/frontend/src/features/settings/types.ts
@@ -7,3 +7,18 @@ export interface TeacherThreshold {
 }
 
 export type ThresholdLoadState = 'loading' | 'error' | 'empty' | 'done'
+
+export type GradingProviderId = 'GEMINI_FLASH' | 'OPENAI_GPT4O' | 'CLAUDE_SONNET'
+
+export interface ProviderOption {
+  id: GradingProviderId
+  displayName: string
+  description: string
+}
+
+export interface GradingProviderSettings {
+  currentProvider: GradingProviderId
+  availableProviders: ProviderOption[]
+}
+
+export type ProviderLoadState = 'loading' | 'error' | 'done'

--- a/packages/frontend/src/features/settings/useGradingProvider.ts
+++ b/packages/frontend/src/features/settings/useGradingProvider.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { getGradingProvider, updateGradingProvider } from './settingsApi'
+import type { GradingProviderId, GradingProviderSettings, ProviderLoadState } from './types'
+
+export function useGradingProvider() {
+  const [loadState, setLoadState] = useState<ProviderLoadState>('loading')
+  const [settings, setSettings] = useState<GradingProviderSettings | null>(null)
+  const [fetchError, setFetchError] = useState('Failed to load grading provider settings.')
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+  const [showSavedSuccess, setShowSavedSuccess] = useState(false)
+  const successTimeoutRef = useRef<number | null>(null)
+
+  const clearSuccessTimeout = useCallback(() => {
+    if (successTimeoutRef.current) {
+      window.clearTimeout(successTimeoutRef.current)
+      successTimeoutRef.current = null
+    }
+  }, [])
+
+  const load = useCallback(async () => {
+    setLoadState('loading')
+    try {
+      const data = await getGradingProvider()
+      setSettings(data)
+      setLoadState('done')
+    } catch {
+      setFetchError('Failed to load grading provider settings. Please try again.')
+      setLoadState('error')
+    }
+  }, [])
+
+  const selectProvider = useCallback(
+    async (provider: GradingProviderId) => {
+      setSaveError(null)
+      setIsSaving(true)
+      clearSuccessTimeout()
+
+      try {
+        const updated = await updateGradingProvider(provider)
+        setSettings(updated)
+        setShowSavedSuccess(true)
+        successTimeoutRef.current = window.setTimeout(() => {
+          setShowSavedSuccess(false)
+          successTimeoutRef.current = null
+        }, 2400)
+      } catch (err: unknown) {
+        const message =
+          err instanceof Error && err.message.includes('PROVIDER_NOT_CONFIGURED')
+            ? 'This provider is not configured — the API key is missing on the server.'
+            : 'Failed to save grading provider. Please try again.'
+        setSaveError(message)
+      } finally {
+        setIsSaving(false)
+      }
+    },
+    [clearSuccessTimeout],
+  )
+
+  useEffect(() => {
+    void load()
+    return () => {
+      clearSuccessTimeout()
+    }
+  }, [clearSuccessTimeout, load])
+
+  return {
+    loadState,
+    settings,
+    fetchError,
+    saveError,
+    isSaving,
+    showSavedSuccess,
+    retryLoad: load,
+    selectProvider,
+  }
+}

--- a/packages/frontend/src/pages/SettingsPage.tsx
+++ b/packages/frontend/src/pages/SettingsPage.tsx
@@ -1,5 +1,7 @@
 import { useTeacherThreshold } from '../features/settings/useTeacherThreshold'
+import { useGradingProvider } from '../features/settings/useGradingProvider'
 import { AppNotice, AppPage, AppPageHeader, AppPanel } from '../components/layout/AppPage'
+import type { GradingProviderId } from '../features/settings/types'
 
 function ThresholdSourceBadge({ source }: { source: 'teacher_override' | 'default' }) {
   if (source === 'teacher_override') {
@@ -32,6 +34,17 @@ export default function SettingsPage() {
     save,
   } = useTeacherThreshold()
 
+  const {
+    loadState: providerLoadState,
+    settings: providerSettings,
+    fetchError: providerFetchError,
+    saveError: providerSaveError,
+    isSaving: providerIsSaving,
+    showSavedSuccess: providerSavedSuccess,
+    retryLoad: retryProviderLoad,
+    selectProvider,
+  } = useGradingProvider()
+
   const showInputError = Boolean(validationError) || Boolean(saveError)
   const activeErrorMessage = validationError ?? saveError
 
@@ -43,6 +56,92 @@ export default function SettingsPage() {
         description="Manage your teacher preferences and the confidence threshold used by AI grading."
       />
 
+      {/* ── AI Grading Model ── */}
+      <AppPanel className="mb-6">
+        <h2 className="font-display text-primary text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>
+          AI Grading Model
+        </h2>
+        <p className="font-body text-secondary text-sm mt-1 mb-4" style={{ color: 'var(--text-secondary)' }}>
+          Choose the AI model used to grade your students' handwritten submissions. Gemini 2.0 Flash is free and recommended.
+        </p>
+
+        {providerLoadState === 'loading' && (
+          <div className="flex items-center gap-3 py-4" style={{ color: 'var(--text-muted)' }}>
+            <svg className="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+            </svg>
+            <span className="font-mono text-xs">Loading preferences...</span>
+          </div>
+        )}
+
+        {providerLoadState === 'error' && (
+          <AppNotice tone="danger">
+            <p className="font-display text-sm font-semibold">Unable to load grading model preferences</p>
+            <p className="font-body text-xs mt-1" style={{ color: 'var(--text-secondary)' }}>{providerFetchError}</p>
+            <button
+              type="button"
+              onClick={() => void retryProviderLoad()}
+              className="mt-3 font-display font-semibold text-xs underline"
+              style={{ color: 'var(--accent-gold)' }}
+            >
+              Retry
+            </button>
+          </AppNotice>
+        )}
+
+        {providerLoadState === 'done' && providerSettings && (
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col">
+              <label
+                htmlFor="grading-provider"
+                className="font-mono text-[11px] mb-1"
+                style={{ color: 'var(--text-muted)' }}
+              >
+                AI Model
+              </label>
+              <select
+                id="grading-provider"
+                value={providerSettings.currentProvider}
+                disabled={providerIsSaving}
+                onChange={(e) => void selectProvider(e.target.value as GradingProviderId)}
+                className="w-72 rounded-xl border bg-elevated px-3 py-2 font-mono text-sm text-primary outline-none focus:ring-1 focus:ring-[var(--accent-gold)] disabled:cursor-not-allowed disabled:opacity-70"
+                style={{
+                  backgroundColor: 'var(--bg-elevated)',
+                  color: 'var(--text-primary)',
+                  border: `1px solid ${providerSaveError ? 'var(--accent-crimson)' : 'var(--border)'}`,
+                }}
+              >
+                {providerSettings.availableProviders.map((opt) => (
+                  <option key={opt.id} value={opt.id}>
+                    {opt.displayName} — {opt.description}
+                  </option>
+                ))}
+              </select>
+              {providerSaveError && (
+                <p className="font-mono text-[11px] mt-1" style={{ color: 'var(--accent-crimson)' }}>
+                  {providerSaveError}
+                </p>
+              )}
+            </div>
+
+            <div className="flex items-center gap-2">
+              {providerIsSaving && (
+                <span className="font-mono text-xs" style={{ color: 'var(--text-muted)' }}>
+                  Saving...
+                </span>
+              )}
+              {providerSavedSuccess && (
+                <span className="text-xs font-mono animate-pulse" style={{ color: 'var(--accent-teal)' }}>
+                  ✓ Saved successfully
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+      </AppPanel>
+
+      {/* ── AI Confidence Threshold ── */}
       <AppPanel className="mb-6">
         <h2 className="font-display text-primary text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>
           AI Confidence Threshold

--- a/strategy/PRD.md
+++ b/strategy/PRD.md
@@ -39,12 +39,13 @@ Features are ordered by priority. The paper exam lifecycle is the product's prim
 | 2 | **Integrated Rubrics** | Each question gets its rubric defined inline during exam creation: expected answer (typed text OR uploaded photo of handwritten answer key), point value, acceptable variations, and grading notes. Rubrics are required before AI grading can run. |
 | 3 | **Exam Print** | Preview a clean, print-ready version of any exam and print it directly from the browser. Multiple choice shows labeled bubbles; open-ended shows lined answer space; multi-part shows indented sub-questions. |
 | 4 | **Exam Export** | Export any exam template as a JSON file for backup or sharing. |
-| 5 | **AI Paper Grading** | Upload a photo (or PDF) of a student's completed paper exam → AI grades every question against the rubric → returns per-question scores, confidence levels, and feedback — instantly. |
+| 5 | **AI Paper Grading** | Upload a photo (or PDF) of a student's completed paper exam → AI grades every question against the rubric → returns per-question scores, confidence levels, and feedback — instantly. Grading uses the teacher's selected AI model from Settings, with Gemini as the default option and OpenAI or Claude available when configured. |
 | 6 | **Confidence Review** | Submissions where AI confidence falls below the teacher's threshold are flagged for manual review. Teacher can approve, adjust, or re-scan. |
 | 7 | **Classes & Students** | Create classes, enroll students, manage rosters. Lightweight — exists to support the grading pipeline. |
 | 8 | **Homework Builder** | Create homework records in a dedicated two-step flow: set planning details first, then define structured questions and expected answers. Homework remains separate from Gradebook rows and AI grading. |
 | 9 | **Gradebook** | View and edit per-student grades across classes. Auto-calculated averages. Populated by AI grading results and manual entry. |
 | 10 | **Auth** | Register/login with JWT. Role selection at signup (only Teacher active for MVP). |
+| 11 | **Settings & Preferences** | Manage account details, confidence review threshold, and the active AI grading provider used for paper-exam grading. |
 
 ## Post-MVP Features
 
@@ -92,7 +93,7 @@ Features are ordered by priority. The paper exam lifecycle is the product's prim
 | Backend | Java 21 + Spring Boot 3.x + Spring Data JPA |
 | Database | PostgreSQL 15+ (RDS) |
 | Auth | JWT + BCrypt via Spring Security |
-| AI | OpenAI Vision API for handwriting grading |
+| AI | Provider-routed handwriting grading: Gemini Flash by default, with OpenAI GPT-4o and Claude Sonnet support when configured |
 | Infra | AWS (S3, CloudFront, ECS, RDS) |
 | Local dev | Docker Compose |
 

--- a/strategy/decisions.md
+++ b/strategy/decisions.md
@@ -303,7 +303,8 @@ The AI-powered grading system uses an asynchronous processing pipeline:
 │               Grading Worker (Spring Boot Service)               │
 │  - Poll SQS for grading jobs                                    │
 │  - Fetch submission images and answer rubric from S3            │
-│  - Call OpenAI Vision API (GPT-4V) with:                        │
+│  - Call the configured AI grading provider with:                │
+│    • Teacher-selected model (Gemini, GPT-4o, or Claude)         │
 │    • Student submission image                                   │
 │    • Answer rubric image                                        │
 │    • Grading instructions                                       │
@@ -325,7 +326,7 @@ The AI-powered grading system uses an asynchronous processing pipeline:
 **Key Design Decisions:**
 - **Asynchronous Processing**: Grading jobs run in background via SQS to handle batch uploads
 - **Image Preprocessing**: Lambda functions ensure consistent image format/quality for AI
-- **OpenAI Vision API**: GPT-4 Vision analyzes both student and rubric images
+- **Provider Router**: Resolve the teacher's saved grading model at runtime; Gemini is the default and OpenAI/Claude are optional when configured
 - **Confidence Threshold**: Configurable (default 95%) to balance automation vs accuracy
 - **Teacher Control**: All AI grades available for review; low-confidence flagged automatically
 - **Scalability**: SQS queue + worker pool can scale horizontally for large batch jobs
@@ -363,6 +364,7 @@ The AI-powered grading system uses an asynchronous processing pipeline:
 | first_name | String(100) | Required | User's first name |
 | last_name | String(100) | Required | User's last name |
 | role | Enum | Required | teacher, principal, counselor |
+| grading_provider | Enum | Required, Default: GEMINI_FLASH | Teacher-selected AI grading provider for paper exam grading |
 | is_active | Boolean | Default: true | Account status |
 | created_at | Timestamp | Required | Account creation time |
 | updated_at | Timestamp | Required | Last update time |
@@ -1446,3 +1448,43 @@ Homework already existed as a lightweight planner entry in navigation, but creat
 - Add `materials_json` to the backend homework entity and API DTOs.
 - Validate homework coverage at save time so each question has a prompt and expected answer.
 - Keep the Homework page copy explicit that planner records do not create Gradebook rows or columns.
+
+---
+
+### ADR-012: Teacher-Selectable AI Grading Providers
+
+**Date:** 2026-04-14  
+**Status:** Accepted  
+**Deciders:** Product owner, development team
+
+#### Context
+
+TraceGrade's grading flow was wired directly to a single OpenAI-backed service. That made it impossible to let teachers choose a model based on cost, latency, or provider preference, and it pushed provider availability concerns into runtime grading failures instead of the settings workflow.
+
+At the same time, the product already exposed teacher-specific grading behavior through the confidence threshold. Model selection belongs in the same teacher-owned settings surface and should persist independently of individual grading requests.
+
+#### Decision
+
+1. Persist the active grading provider on the teacher user record as `grading_provider`, defaulting to `GEMINI_FLASH`.
+2. Introduce a provider-agnostic grading contract plus a `GradingProviderRouter` that resolves the teacher's saved provider at grading time.
+3. Support three provider IDs in the settings and grading pipeline: `GEMINI_FLASH`, `OPENAI_GPT4O`, and `CLAUDE_SONNET`.
+4. Add teacher settings endpoints for reading and updating the active grading provider.
+5. Validate provider configuration when a teacher saves settings so unconfigured providers fail early with a stable `PROVIDER_NOT_CONFIGURED` API error.
+
+#### Consequences
+
+**Positive:**
+- Teachers can choose their grading model without changing exam or submission data.
+- The grading service is no longer tightly coupled to one provider implementation.
+- Missing API keys surface as a settings-time validation problem instead of a later grading surprise.
+
+**Trade-offs:**
+- The backend now owns provider routing, provider-specific exceptions, and an extra persistence field on users.
+- Frontend settings flows must preserve structured backend error codes so they can show provider-specific guidance.
+- More providers increase the test matrix for grading behavior and configuration paths.
+
+#### Implementation Notes
+
+- Store the provider enum on `users.grading_provider` with `GEMINI_FLASH` as the schema default.
+- Keep OpenAI as one routed provider rather than renaming the existing OpenAI service abstraction immediately.
+- Return provider metadata from the settings API so the frontend can render labels and descriptions without hardcoding a second source of truth.

--- a/strategy/learnings.md
+++ b/strategy/learnings.md
@@ -85,3 +85,6 @@ Teachers think in terms of classes first, not detached templates. The exam build
 
 ### Breadcrumb history should track only main pages
 Recent-navigation breadcrumbs are most useful when they reflect workspace changes, not every detail route. Track only top-level pages like Dashboard, Students, Grades, and Settings, keep the list FIFO-capped at five entries, and let detail workspaces reuse the last main-page context instead of polluting history.
+
+### Preserve structured backend error codes through frontend settings APIs
+Settings flows sometimes need specific UX copy, not just a generic save failure. When the backend returns a stable code like `PROVIDER_NOT_CONFIGURED`, the frontend API layer should keep that code intact so hooks and pages can explain the actual configuration problem instead of showing a vague retry message.

--- a/strategy/roles.md
+++ b/strategy/roles.md
@@ -25,7 +25,7 @@ The primary user. TraceGrade is built around the teacher's paper exam lifecycle:
 | **Students** | Add, edit, deactivate students; open a full student profile page with roster details, class placement, recorded grades, and performance summaries. |
 | **Grades** | View gradebook per class; enter/edit individual grades; auto-calculated averages. |
 | **Auth** | Register, login, JWT-based sessions. |
-| **Settings** | Account settings, confidence threshold configuration. |
+| **Settings** | Account settings, confidence threshold configuration, AI grading model selection. |
 
 ### Planned additions
 

--- a/strategy/use-cases.md
+++ b/strategy/use-cases.md
@@ -559,7 +559,7 @@ Feature: Homework Management
 
 ### UC-T-11: Account Settings
 
-**Feature:** The teacher manages their own account information.
+**Feature:** The teacher manages their own account information and grading preferences.
 
 ```gherkin
 Feature: Account Settings
@@ -570,12 +570,34 @@ Feature: Account Settings
   Scenario: View current account settings
     Given the teacher navigates to the Settings page
     Then they see their current name and email displayed
+    And they see their active confidence review threshold
+    And they see their selected AI grading model
 
   Scenario: Update account information
     Given the teacher is on the Settings page
     When they update their name or any editable field
     And save the changes
     Then the updated information is reflected in the UI
+
+  Scenario: Update confidence review threshold
+    Given the teacher is on the Settings page
+    When they set a valid confidence review threshold and save
+    Then the updated threshold is reflected in the UI
+    And future AI review gating uses that saved threshold
+
+  Scenario: Update AI grading model
+    Given the teacher is on the Settings page
+    And the selected AI provider is configured on the server
+    When they choose a different AI grading model and save
+    Then the selected AI grading model is persisted for that teacher
+    And future grading requests use that saved model
+
+  Scenario: Reject an AI grading model that is not configured
+    Given the teacher is on the Settings page
+    And the selected AI provider is missing its server API key
+    When they try to save that AI grading model
+    Then the selected AI grading model remains unchanged
+    And the UI explains that the provider is not configured
 
   Scenario: Navigate back to dashboard from Settings
     Given the teacher is on the Settings page


### PR DESCRIPTION
## Description

This PR adds teacher-selectable AI grading providers to the paper-exam flow and fixes LocalStack browser preview URLs. Teachers can now save Gemini Flash, GPT-4o, or Claude Sonnet in Settings; grading routes through the saved provider; unconfigured providers fail early with a stable `PROVIDER_NOT_CONFIGURED` error; and the backend now advertises `localhost`-based S3 preview URLs for host-browser image access.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD changes
- [ ] Other (please describe):

## Related Issues

Fixes n/a
Relates to n/a

## Changes Made

- Add per-teacher grading provider persistence, settings endpoints, provider routing, and provider-specific exceptions
- Add Gemini Flash and Claude Sonnet grading services alongside routed OpenAI support
- Update the Settings page and settings API flow to load, save, and validate the active grading model
- Restore `S3_PUBLIC_ENDPOINT=http://localhost:4566` so browser-facing preview URLs work outside Docker
- Sync product, role, use-case, decision, and learning docs with the new grading-provider behavior

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

### Test Steps

1. Run `npm.cmd run test:run -- src/features/settings/settingsApi.test.ts` in `packages/frontend`
2. Run the targeted backend test files for `S3StorageServiceTest`, `AnswerRubricServiceTest`, `GradingServiceImplTest`, `GradingProviderRouterTest`, and `GradingProviderControllerTest`
3. Run `docker compose up -d --build --force-recreate backend` and verify `S3_PUBLIC_ENDPOINT=http://localhost:4566` via `docker inspect tracegrade-backend`

## Screenshots

Not included

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Context

The backend container was recreated after the compose fix and now reports `S3_PUBLIC_ENDPOINT=http://localhost:4566`. Existing build warnings in `SecurityConfig` and older Spring test mocks are pre-existing and unchanged by this PR.